### PR TITLE
fix: specify mean_type for external statistics

### DIFF
--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -113,6 +113,7 @@ async def async_insert_statistics(
         metadata = StatisticMetaData(
             has_mean=False,
             has_sum=True,
+            mean_type=None,
             name=f"{obj[CONF_NAME]} ({data_type})",
             source=DOMAIN,
             statistic_id=statistic_id,
@@ -169,6 +170,7 @@ async def async_insert_cost_statistics(
     cost_metadata = StatisticMetaData(
         has_mean=False,
         has_sum=True,
+        mean_type=None,
         name=f"{obj[CONF_NAME]} ({CONF_COST})",
         source=DOMAIN,
         statistic_id=f"{DOMAIN}:energy_{CONF_COST}_{obj[CONF_ID]}",


### PR DESCRIPTION
Fixes warning for Home Assistant 2026.11: add mean_type to StatisticMetaData when calling async_add_external_statistics.

Refs: #23