### PR TITLE
Support mandatory email 2FA (Drupal TFA) via IMAP with session reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,46 @@ If you wish for real-time statistics - consider using 3rd party meters (like She
 
 ### Integration
 
-| Name     |  Type  | Required | Default | Description          |
-|----------|:------:|:--------:|:-------:|----------------------|
-| username | string |   yes    |         | ESO username / email |
-| password | string |   yes    |         | ESO password         |
-| objects  |  list  |   yes    |         | List of objects      |
+| Name     |  Type  | Required | Default | Description                                                            |
+|----------|:------:|:--------:|:-------:|------------------------------------------------------------------------|
+| username | string |   yes    |         | ESO username / email                                                   |
+| password | string |   yes    |         | ESO password                                                           |
+| objects  |  list  |   yes    |         | List of objects                                                        |
+| imap     |  map   |    no    |         | Mailbox used to read ESO's two-factor login codes (see *Two-factor authentication*) |
+
+### Two-factor authentication
+
+ESO now sends a mandatory one-time code by email on **every** login. When an `imap`
+section is configured, the integration completes that step automatically: it reads
+the latest code from your mailbox and submits it. To keep email traffic to a minimum
+it persists the authenticated session (`eso_session.json` in the HA config directory,
+valid ~3 weeks) and only performs a full login + 2FA when that session has expired.
+
+If `imap` is omitted the integration behaves as before and will fail to log in while
+2FA is enforced on your account.
+
+| Name     |  Type  | Required |    Default     | Description                                                                 |
+|----------|:------:|:--------:|:--------------:|-----------------------------------------------------------------------------|
+| host     | string |   yes    | imap.gmail.com | IMAP server host                                                            |
+| port     |  int   |   yes    |      993       | IMAP server port (SSL)                                                      |
+| username | string |   yes    |                | Mailbox username                                                            |
+| password | string |   yes    |                | Mailbox password. For Gmail this must be an [app password](https://support.google.com/accounts/answer/185833), not the account password |
+| sender   | string |    no    | savitarna@eso.lt | Sender address the 2FA code is matched on                                 |
+| folder   | string |    no    |     INBOX      | Mailbox folder to search                                                    |
+
+```yaml
+eso:
+  username: your_username
+  password: your_password
+  imap:
+    host: imap.gmail.com
+    port: 993
+    username: your_mailbox@gmail.com
+    password: your_app_password
+  objects:
+    - name: My House
+      id: 123456
+```
 
 ### Object
 

--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -29,6 +29,12 @@ CONF_RETURNED = "returned"
 CONF_COST = "cost"
 CONF_PRICE_ENTITY = "price_entity"
 CONF_PRICE_CURRENCY = "price_currency"
+CONF_IMAP = "imap"
+CONF_IMAP_HOST = "host"
+CONF_IMAP_PORT = "port"
+CONF_IMAP_SENDER = "sender"
+CONF_IMAP_FOLDER = "folder"
+SESSION_FILE = "eso_session.json"
 POWER_CONSUMED = "P+"
 POWER_RETURNED = "P-"
 ENERGY_TYPE_MAP = {
@@ -43,11 +49,20 @@ OBJECT_SCHEMA = vol.Schema({
     vol.Optional(CONF_PRICE_ENTITY): cv.string,
     vol.Optional(CONF_PRICE_CURRENCY, default="EUR"): cv.string,
 })
+IMAP_SCHEMA = vol.Schema({
+    vol.Required(CONF_IMAP_HOST, default="imap.gmail.com"): cv.string,
+    vol.Required(CONF_IMAP_PORT, default=993): cv.port,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_IMAP_SENDER, default="savitarna@eso.lt"): cv.string,
+    vol.Optional(CONF_IMAP_FOLDER, default="INBOX"): cv.string,
+})
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_OBJECTS): cv.ensure_list(OBJECT_SCHEMA),
+        vol.Optional(CONF_IMAP): IMAP_SCHEMA,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -57,9 +72,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if DOMAIN not in config:
         return True
     hass.data.setdefault(DOMAIN, config[DOMAIN])
+    imap_config = config[DOMAIN].get(CONF_IMAP)
+    if imap_config:
+        imap_config = {
+            "host": imap_config[CONF_IMAP_HOST],
+            "port": imap_config[CONF_IMAP_PORT],
+            "username": imap_config[CONF_USERNAME],
+            "password": imap_config[CONF_PASSWORD],
+            "sender": imap_config[CONF_IMAP_SENDER],
+            "folder": imap_config[CONF_IMAP_FOLDER],
+        }
     client = ESOClient(
         username=config[DOMAIN][CONF_USERNAME],
-        password=config[DOMAIN][CONF_PASSWORD]
+        password=config[DOMAIN][CONF_PASSWORD],
+        imap_config=imap_config,
+        session_file=hass.config.path(SESSION_FILE),
     )
 
     async def async_import_generation(now: datetime, retry: bool = False) -> None:

--- a/custom_components/eso/eso_client.py
+++ b/custom_components/eso/eso_client.py
@@ -1,4 +1,10 @@
 import logging
+import re
+import json
+import time
+import imaplib
+import email
+from email.header import decode_header
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 import requests
@@ -6,46 +12,263 @@ from .form_parser import FormParser
 
 LOGIN_URL = "https://mano.eso.lt/?destination=/consumption"
 GENERATION_URL = "https://mano.eso.lt/consumption?ajax_form=1&_wrapper_format=drupal_ajax"
+TFA_FORM_ID = "gpc_tfa_login_auth_form"
+CONSUMPTION_FORM_ID = "eso_consumption_history_form"
+USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+# How long to wait for the 2FA code email to arrive (the message is sent by
+# ESO the moment the password POST lands on the TFA page).
+OTP_POLL_TIMEOUT = 120
+OTP_POLL_INTERVAL = 5
 MONTHS = [
     "Sausio", "Vasario", "Kovo", "Balandžio", "Gegužės", "Birželio", "Liepos", "Rugpjūčio", "Rugsėjo", "Spalio", "Lapkričio", "Gruodžio"
 ]
 _LOGGER = logging.getLogger(__name__)
 
+
 class ESOClient:
-    def __init__(self, username: str, password: str):
+    def __init__(self, username: str, password: str, imap_config: dict | None = None, session_file: str | None = None):
         self.username: str = username
         self.password: str = password
-        self.session: requests.Session = requests.Session()
+        self.imap_config: dict | None = imap_config
+        self.session_file: str | None = session_file
+        self.session: requests.Session = self._new_session()
         self.cookies: dict | None = None
         self.form_parser: FormParser = FormParser()
         self.dataset: dict = {}
 
+    @staticmethod
+    def _new_session() -> requests.Session:
+        session = requests.Session()
+        session.headers.update({"User-Agent": USER_AGENT})
+        return session
+
     def login(self) -> None:
+        """Establish an authenticated ESO session.
+
+        Strategy: reuse a persisted Drupal session cookie (valid ~3 weeks) so
+        we avoid triggering a 2FA email on every daily run. Only when the
+        stored session is gone/expired do we perform the full
+        password -> email-OTP login. ESO sends a fresh code on *every* login,
+        so session reuse is the only way to keep 2FA emails to ~monthly.
+        """
         self.dataset = {}
         try:
-            response = self.session.post(
-                LOGIN_URL,
-                data={
-                    "name": self.username,
-                    "pass": self.password,
-                    "login_type": 1,
-                    "form_id": "user_login_form"
-                },
-                allow_redirects=True
-            )
-            response.raise_for_status()
-            _LOGGER.debug(f"Got login response: {response.text}")
-            self.cookies = requests.utils.dict_from_cookiejar(response.cookies)
-            self.form_parser.feed(response.text)
+            if self._load_session() and self._open_consumption():
+                _LOGGER.info("ESO: reused stored session, skipping 2FA login")
+                return
+            _LOGGER.info("ESO: no valid stored session, performing full login")
+            self.session = self._new_session()
+            self._full_login()
+            if self._open_consumption():
+                self._save_session()
+                _LOGGER.info("ESO: full login successful, session saved")
+            else:
+                _LOGGER.error("ESO login did not reach the consumption page")
         except requests.exceptions.RequestException as e:
             _LOGGER.error(f"ESO login error: {e}")
+        except Exception as e:  # noqa: BLE001 - surface IMAP/parse failures too
+            _LOGGER.error(f"ESO login failed: {e}")
+
+    def _open_consumption(self) -> bool:
+        """GET the consumption page with the current session and parse its
+        Drupal form tokens. Returns True when the session is authenticated
+        (i.e. the consumption form is present rather than the login form)."""
+        self.form_parser = FormParser()
+        response = self.session.get(LOGIN_URL, allow_redirects=True)
+        response.raise_for_status()
+        self.cookies = requests.utils.dict_from_cookiejar(self.session.cookies)
+        self.form_parser.feed(response.text)
+        return self.form_parser.get("form_id") == CONSUMPTION_FORM_ID
+
+    def _full_login(self) -> None:
+        """Submit the username/password form. ESO redirects to the TFA page
+        and emails a one-time code, which we then retrieve and submit."""
+        response = self.session.post(
+            LOGIN_URL,
+            data={
+                "name": self.username,
+                "pass": self.password,
+                "login_type": 1,
+                "form_id": "user_login_form",
+            },
+            allow_redirects=True,
+        )
+        response.raise_for_status()
+        if "/user/login/tfa/" not in response.url:
+            # Either already logged in (unlikely with fresh session) or the
+            # credentials were rejected. _open_consumption() will decide.
+            _LOGGER.debug("ESO: no TFA redirect, login response url=%s", response.url)
             return
+        login_started = datetime.now()
+        tfa_url = response.url
+        build_id = self._extract_tfa_build_id(response.text)
+        if not build_id:
+            _LOGGER.error("ESO: could not find TFA form_build_id on %s", tfa_url)
+            return
+        code = self._fetch_otp(login_started)
+        if not code:
+            _LOGGER.error("ESO: did not receive a 2FA code via IMAP in time")
+            return
+        _LOGGER.info("ESO: submitting 2FA code")
+        submit = self.session.post(
+            tfa_url,
+            data={
+                "code": code,
+                "submit_code": "Submit code",
+                "form_build_id": build_id,
+                "form_id": TFA_FORM_ID,
+            },
+            allow_redirects=True,
+        )
+        submit.raise_for_status()
+
+    @staticmethod
+    def _extract_tfa_build_id(html: str) -> str | None:
+        """Pull form_build_id out of the gpc-tfa-login-auth-form only, so we
+        don't pick up another form's token from the same page."""
+        marker = "gpc-tfa-login-auth-form"
+        if marker not in html:
+            return None
+        segment = html.split(marker, 1)[1].split("</form>", 1)[0]
+        for tag in re.findall(r"<input[^>]+>", segment):
+            if "form_build_id" in tag:
+                value = re.search(r'value="([^"]*)"', tag)
+                if value:
+                    return value.group(1)
+        return None
+
+    # ---- IMAP one-time-code retrieval -------------------------------------
+
+    def _fetch_otp(self, login_started: datetime) -> str | None:
+        if not self.imap_config:
+            _LOGGER.error("ESO: 2FA required but no IMAP config provided")
+            return None
+        cfg = self.imap_config
+        deadline = time.monotonic() + OTP_POLL_TIMEOUT
+        # Only accept messages that arrived after we triggered the login,
+        # with a small clock-skew allowance, so we never reuse a stale code.
+        min_time = login_started - timedelta(minutes=2)
+        while time.monotonic() < deadline:
+            try:
+                code = self._poll_imap_once(cfg, min_time)
+                if code:
+                    return code
+            except Exception as e:  # noqa: BLE001
+                _LOGGER.warning("ESO: IMAP poll error: %s", e)
+            time.sleep(OTP_POLL_INTERVAL)
+        return None
+
+    def _poll_imap_once(self, cfg: dict, min_time: datetime) -> str | None:
+        conn = imaplib.IMAP4_SSL(cfg["host"], cfg.get("port", 993))
+        try:
+            conn.login(cfg["username"], cfg["password"])
+            conn.select(cfg.get("folder", "INBOX"))
+            since = min_time.strftime("%d-%b-%Y")
+            typ, data = conn.search(None, f'(FROM "{cfg["sender"]}" SINCE {since})')
+            if typ != "OK" or not data or not data[0]:
+                return None
+            ids = data[0].split()
+            # Newest first.
+            for msg_id in reversed(ids):
+                typ, msg_data = conn.fetch(msg_id, "(RFC822)")
+                if typ != "OK" or not msg_data or not msg_data[0]:
+                    continue
+                msg = email.message_from_bytes(msg_data[0][1])
+                msg_dt = self._parse_msg_date(msg)
+                if msg_dt and msg_dt < min_time:
+                    continue
+                code = self._extract_code(self._message_text(msg))
+                if code:
+                    return code
+            return None
+        finally:
+            try:
+                conn.logout()
+            except Exception:  # noqa: BLE001
+                pass
+
+    @staticmethod
+    def _parse_msg_date(msg) -> datetime | None:
+        raw = msg.get("Date")
+        if not raw:
+            return None
+        try:
+            dt = email.utils.parsedate_to_datetime(raw)
+            # Compare naively in local time; strip tz to match login_started.
+            return dt.astimezone().replace(tzinfo=None)
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _message_text(msg) -> str:
+        parts = []
+        if msg.is_multipart():
+            for part in msg.walk():
+                ctype = part.get_content_type()
+                if ctype in ("text/plain", "text/html"):
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        charset = part.get_content_charset() or "utf-8"
+                        parts.append(payload.decode(charset, errors="replace"))
+        else:
+            payload = msg.get_payload(decode=True)
+            if payload:
+                charset = msg.get_content_charset() or "utf-8"
+                parts.append(payload.decode(charset, errors="replace"))
+        return "\n".join(parts)
+
+    @staticmethod
+    def _extract_code(text: str) -> str | None:
+        if not text:
+            return None
+        # Strip HTML tags so "Jūsų kodas:" and the code aren't split by markup.
+        plain = re.sub(r"<[^>]+>", " ", text)
+        plain = re.sub(r"\s+", " ", plain)
+        # Anchor on the "kodas" label, then take the next 6-digit group.
+        m = re.search(r"kodas\D{0,40}?(\d{6})", plain, re.IGNORECASE)
+        if m:
+            return m.group(1)
+        # Fallback: any standalone 6-digit number.
+        m = re.search(r"(?<!\d)(\d{6})(?!\d)", plain)
+        return m.group(1) if m else None
+
+    # ---- session persistence ----------------------------------------------
+
+    def _save_session(self) -> None:
+        if not self.session_file:
+            return
+        try:
+            jar = requests.utils.dict_from_cookiejar(self.session.cookies)
+            with open(self.session_file, "w") as fh:
+                json.dump(jar, fh)
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning("ESO: could not save session: %s", e)
+
+    def _load_session(self) -> bool:
+        if not self.session_file:
+            return False
+        try:
+            with open(self.session_file) as fh:
+                jar = json.load(fh)
+        except FileNotFoundError:
+            return False
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning("ESO: could not load session: %s", e)
+            return False
+        if not jar:
+            return False
+        self.session = self._new_session()
+        self.session.cookies = requests.utils.cookiejar_from_dict(jar)
+        return True
 
     def fetch(self, obj: str, date: datetime) -> dict:
         if not self.cookies:
             _LOGGER.error("Cookies are empty. Check your credentials.")
             return {}
-        if self.form_parser.get("form_id") != "eso_consumption_history_form":
+        if self.form_parser.get("form_id") != CONSUMPTION_FORM_ID:
             _LOGGER.error("Form ID not found. Check your credentials OR login to ESO and confirm contact information.")
             return {}
         headers = {


### PR DESCRIPTION
Closes #29

## Problem

ESO enabled **mandatory two-factor authentication** on `mano.eso.lt`: a one-time code is emailed on **every** login (Drupal TFA module). The current single password POST no longer reaches the consumption page — it lands on `/user/login/tfa/{uid}/{hash}` instead — so `fetch()` bails at the `form_id != eso_consumption_history_form` check and **statistics import breaks entirely** once 2FA is enforced on an account.

## Solution

Adds an optional `imap` config block. When present, `login()`:

1. **Reuses a persisted Drupal session cookie** (`eso_session.json` in the HA config dir, valid ~3 weeks) so a 2FA email is *not* triggered on every daily run — only when the session has actually expired.
2. On a full login, follows the TFA redirect, **reads the latest code from the configured mailbox** (filtered by sender + message date, anchored on the "kodas" label, 6 digits), and submits `gpc_tfa_login_auth_form`.
3. Re-opens `/consumption` to refresh the form tokens and saves the session.

If `imap` is omitted, behaviour is **unchanged** (and login will fail while 2FA is enforced, as it does today).

## Config

```yaml
eso:
  username: your_username
  password: your_password
  imap:
    host: imap.gmail.com
    port: 993
    username: your_mailbox@gmail.com
    password: your_app_password   # Gmail requires an App Password, not the account password
  objects:
    - name: My House
      id: 123456
```

| Name | Required | Default | Description |
|------|:--------:|:-------:|-------------|
| host | yes | imap.gmail.com | IMAP server host |
| port | yes | 993 | IMAP SSL port |
| username | yes | | Mailbox username |
| password | yes | | Mailbox password (Gmail: app password) |
| sender | no | savitarna@eso.lt | Sender the code is matched on |
| folder | no | INBOX | Folder to search |

## Testing

Verified live against a real ESO account with Gmail IMAP:

- ✅ Full login → TFA redirect → code fetched from inbox → submitted → reached `eso_consumption_history_form`
- ✅ Correctly ignores **stale** codes (date filter) and picks the freshly-sent one
- ✅ `fetch_dataset` returned a full week of real hourly data (168 points, consumed + returned series)
- ✅ Second login **reused the stored session** with no 2FA email
- ✅ HA config check passes; integration loads cleanly

## Notes

- New runtime dependency is stdlib only (`imaplib`, `email`); no manifest change.
- Scope kept to 2FA only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)