### PR TITLE
Fix cumulative sum reset after import gaps

### DIFF
--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -146,17 +146,22 @@ async def _async_get_statistics(hass: HomeAssistant, metadata: StatisticMetaData
     return statistics
 
 async def get_previous_sum(hass: HomeAssistant, metadata: StatisticMetaData, date: datetime) -> float:
+    # Look back far enough to survive multi-day fetch failures and take the most
+    # recent point before `date`. A 1-hour lookup silently resets the cumulative
+    # sum to 0 whenever a gap appears (e.g. failed imports), which corrupts the
+    # long-term energy statistics from that point on.
     statistic_id = metadata["statistic_id"]
-    start = date - timedelta(hours=1)
+    start = date - timedelta(days=60)
     end = date
     _LOGGER.debug(f"Looking history sum for {statistic_id} for {date} between {start} and {end}")
     stat = await get_instance(hass).async_add_executor_job(
         statistics_during_period, hass, start, end, {statistic_id}, "hour", None, {"sum"}
     )
-    if statistic_id not in stat:
+    rows = stat.get(statistic_id) if stat else None
+    if not rows:
         _LOGGER.debug(f"No history sum found")
         return 0.0
-    sum_ = stat[statistic_id][0]["sum"]
+    sum_ = rows[-1].get("sum") or 0.0
     _LOGGER.debug(f"History sum for {statistic_id} = {sum_}")
     return sum_
 


### PR DESCRIPTION
## Problem

`get_previous_sum()` fetches the last cumulative sum so a new import batch can continue the running total (`has_sum=True` external statistics). It looks back only **1 hour** before the first point of the new batch:

```python
start = date - timedelta(hours=1)
...
if statistic_id not in stat:
    return 0.0
sum_ = stat[statistic_id][0]["sum"]
```

`date` is the **earliest** point of the freshly-fetched batch (~a week ago). If an import failed for a while — ESO/network outage, or login breaking — there is no stored statistic in that narrow 1-hour window. `statistic_id not in stat` is then true, the function returns `0.0`, and the cumulative sum is **reset to zero**. Every consumption/return/cost figure after the gap is corrupted in the long-term statistics and the Energy dashboard.

## Fix

```python
start = date - timedelta(days=60)
...
rows = stat.get(statistic_id) if stat else None
if not rows:
    return 0.0
sum_ = rows[-1].get("sum") or 0.0
```

- Widen the lookback to 60 days so the previous total is found across gaps of any realistic length.
- Take `rows[-1]` (the **most recent** point before `date`) rather than `[0]` — required now that the window can contain many rows.
- Guard against a missing/`None` `sum`.

Behaviour is unchanged in the normal no-gap case (the most recent prior point is still the one an hour earlier); it only stops the erroneous reset when that point is missing.

## Testing

- Syntax/compile check passes; change is isolated to `get_previous_sum`.
- Running in production against a real account with gapped history; the cumulative sum continues correctly instead of resetting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)