### PR TITLE
Ignitis data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,20 @@ as well as improve motivation and helps me understand, that this project is usef
 <a href="https://www.buymeacoffee.com/algirdasci" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
 # Intro
-This integration is for users which have smart [ESO](https://mano.eso.lt/) energy meters and does not have
+This integration is for users which have smart energy meters and do not have
 technical possibilities to add P1 interface (for example meter is far away from wireless reception).
-Keep in mind, that ESO site provides data for last 24 hours,
-therefore refresh rate is quite slow (check for new data is performed every 2 hours).
+It supports two data providers, selectable during setup:
+
+- **[ESO](https://mano.eso.lt/)** – signs in with your mano.eso.lt account. ESO emails a one-time
+  code on every login, so a mailbox is required to read it automatically. The daily import runs once
+  per day at a random time between 05:10 and 07:10 to avoid all installations calling ESO at once.
+- **Ignitis** – signs in with your **Ignitis "Energy Smart" app credentials** (the same email and
+  password you use in the Energy Smart app). No mailbox/two-factor step is needed. The daily import
+  runs at 10:30, once the previous day's data is published; if it isn't ready yet, it retries every
+  10 minutes for a while.
+
+Keep in mind that providers publish data for the previous day only, so the refresh rate is slow.
 If you wish for real-time statistics - consider using 3rd party meters (like Shelly 3EM) or utilise P1 interface of smart meter.
-The daily ESO import is scheduled once per day at a random time between 05:10 and 07:10 to avoid all installations calling ESO at the same moment.
 
 ### Disclaimer
 
@@ -43,15 +51,17 @@ Legacy YAML configuration is **deprecated**; any existing `eso:` block is automa
 
 1. Go to **Settings → Devices & Services → Add Integration**
 2. Search for **ESO Energy Consumption**
-3. **Step 1 – ESO account:** enter your [mano.eso.lt](https://mano.eso.lt/) username and password.
-4. **Step 2 – Two-factor authentication (email):** ESO emails a one-time code on every login, so a mailbox is **required**. Enter the mailbox that receives those codes so Home Assistant can read them automatically (see *Two-factor authentication* below).
-5. **Step 3 – Select objects:** the integration logs in and **auto-discovers your eso objects**.
+3. **Step 1 – Account:** choose your **data provider** (ESO or Ignitis) and enter your credentials.
+   - **ESO:** your [mano.eso.lt](https://mano.eso.lt/) username and password.
+   - **Ignitis:** your **Ignitis "Energy Smart"** app email and password.
+4. **Step 2 – Two-factor authentication (email):** *ESO only.* ESO emails a one-time code on every login, so a mailbox is **required**. Enter the mailbox that receives those codes so Home Assistant can read them automatically (see *Two-factor authentication* below). Ignitis skips this step.
+5. **Step 3 – Select objects:** the integration logs in and **auto-discovers your objects**.
 
 After setup, the account appears under **Settings → Devices & Services** with each object listed beneath it:
 
 - **Add object** – discovers your objects and adds one as a new entry.
-- **Reconfigure** (per object) – set that object's name, consumed/returned tracking, and an optional price entity for cost statistics — directly on the object, no nested menus.
-- **Configure** (on the account) – update the ESO password and mailbox (2FA) settings.
+- **Reconfigure** (per object) – set that object's name, consumed/returned tracking, and cost/balance options — directly on the object, no nested menus.
+- **Configure** (on the account) – update the account password (and, for ESO, the mailbox/2FA settings).
 - **Delete** (per object) – stop tracking that object.
 
 #### Migrating from YAML
@@ -59,7 +69,9 @@ After setup, the account appears under **Settings → Devices & Services** with 
  If you already have an `eso:` block in `configuration.yaml`, it is imported automatically into a config entry on the next restart.
  Once the integration appears under **Settings → Devices & Services**, remove the `eso:` block from `configuration.yaml`.
 
-### Two-factor authentication
+### Two-factor authentication (ESO only)
+
+This applies to the **ESO** provider only; Ignitis signs in directly and needs no mailbox.
 
 ESO now sends a mandatory one-time code by email on **every** login. When a mailbox
 is configured (UI step 2), the integration completes that step automatically: it reads
@@ -93,6 +105,8 @@ Each object (metering point) exposes the following settings via **Reconfigure**:
 | returned       | boolean |    no    |  False  | Generate statistics for returned energy              |
 | price_entity   | string  |    no    |         | Name of an entity tracking electricity price         |
 | price_currency | string  |    no    |   EUR   | Currency of electricity price                        |
+| fixed_price    |  float  |    no    |         | Flat price per kWh, used for cost when no price entity is set |
+| export_balance | boolean |    no    |  False  | Track the accumulated export balance reported by Ignitis     |
 
 ### Example with cost calculation
 
@@ -119,6 +133,15 @@ HA entity tracking energy costs.
 
 To display the Cost information in the HA Energy dashboard, in the Energy configuration popup click the `Use an entity tracking
 the total costs` option and select the entity called `My House (cost)`.
+
+If you have a flat tariff instead of an hourly price sensor, leave **price entity** empty and set a
+**fixed price** per kWh on the object; the cost statistics are then calculated from that flat rate.
+
+### On-demand import
+
+The `eso.import_now` service triggers an import immediately instead of waiting for the daily run.
+It accepts an optional **date** — set it to (re)import a specific past day (for example, to backfill a
+day that was missed).
 
 
 # TODO

--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -2,7 +2,7 @@ import logging
 import random
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -33,8 +33,11 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_CONFIG_ENTRY_ID,
+    ATTR_DATE,
     CONF_CONSUMED,
     CONF_COST,
+    CONF_EXPORT_BALANCE,
+    CONF_FIXED_PRICE,
     CONF_IMAP,
     CONF_IMAP_FOLDER,
     CONF_IMAP_HOST,
@@ -43,33 +46,43 @@ from .const import (
     CONF_OBJECTS,
     CONF_PRICE_CURRENCY,
     CONF_PRICE_ENTITY,
+    CONF_PROVIDER,
     CONF_RETURNED,
+    DAILY_IMPORT_WINDOW_SECONDS,
+    DAILY_IMPORT_WINDOW_START_HOUR,
+    DAILY_IMPORT_WINDOW_START_MINUTE,
     DEFAULT_IMAP_FOLDER,
     DEFAULT_IMAP_HOST,
     DEFAULT_IMAP_PORT,
     DEFAULT_IMAP_SENDER,
     DEFAULT_PRICE_CURRENCY,
+    DEFAULT_PROVIDER,
     DOMAIN,
     ENERGY_TYPE_MAP,
+    EXPORT_BALANCE_KEY,
+    IGNITIS_IMPORT_HOUR,
+    IGNITIS_IMPORT_MINUTE,
+    IGNITIS_MAX_RETRIES,
+    IGNITIS_RETRY_DELAY_SECONDS,
+    PROVIDER_IGNITIS,
+    PROVIDERS,
     RETRY_DELAY_SECONDS,
     SERVICE_IMPORT_NOW,
     SESSION_FILE,
     SUBENTRY_TYPE_OBJECT,
+    TIMEZONE,
 )
-from .eso_client import ESOClient
+from .eso_client import ESOAuthError, ESOClient
+from .ignitis_client import IgnitisClient
 
 _LOGGER = logging.getLogger(__name__)
-
-DAILY_IMPORT_WINDOW_START_HOUR = 5
-DAILY_IMPORT_WINDOW_START_MINUTE = 10
-DAILY_IMPORT_WINDOW_SECONDS = 2 * 3600
 
 
 @dataclass
 class ESORuntimeData:
     """Runtime data stored on the config entry."""
 
-    client: ESOClient
+    client: ESOClient | IgnitisClient
     async_import: Callable[[datetime], Awaitable[None]]
 
 
@@ -83,6 +96,8 @@ OBJECT_SCHEMA = vol.Schema(
         vol.Required(CONF_RETURNED, default=False): cv.boolean,
         vol.Optional(CONF_PRICE_ENTITY): cv.string,
         vol.Optional(CONF_PRICE_CURRENCY, default=DEFAULT_PRICE_CURRENCY): cv.string,
+        vol.Optional(CONF_FIXED_PRICE): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Required(CONF_EXPORT_BALANCE, default=False): cv.boolean,
     }
 )
 IMAP_SCHEMA = vol.Schema(
@@ -101,6 +116,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): cv.string,
                 vol.Required(CONF_PASSWORD): cv.string,
+                vol.Optional(CONF_PROVIDER, default=DEFAULT_PROVIDER): vol.In(PROVIDERS),
                 vol.Required(CONF_OBJECTS): cv.ensure_list(OBJECT_SCHEMA),
                 vol.Optional(CONF_IMAP): IMAP_SCHEMA,
             }
@@ -110,11 +126,22 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 SERVICE_IMPORT_NOW_SCHEMA = vol.Schema(
-    {vol.Optional(ATTR_CONFIG_ENTRY_ID): vol.All(cv.ensure_list, [cv.string])}
+    {vol.Optional(ATTR_CONFIG_ENTRY_ID): vol.All(cv.ensure_list, [cv.string]), vol.Optional(ATTR_DATE): cv.datetime}
 )
 
 
-def _random_daily_import_time(now: datetime) -> datetime:
+def _next_import_time(now: datetime, provider: str) -> datetime:
+    if provider == PROVIDER_IGNITIS:
+        start = now.replace(
+            hour=IGNITIS_IMPORT_HOUR,
+            minute=IGNITIS_IMPORT_MINUTE,
+            second=0,
+            microsecond=0,
+        )
+        if now >= start:
+            start += timedelta(days=1)
+        return start
+
     start = now.replace(
         hour=DAILY_IMPORT_WINDOW_START_HOUR,
         minute=DAILY_IMPORT_WINDOW_START_MINUTE,
@@ -124,6 +151,23 @@ def _random_daily_import_time(now: datetime) -> datetime:
     if now >= start:
         start += timedelta(days=1)
     return start + timedelta(seconds=random.randint(0, DAILY_IMPORT_WINDOW_SECONDS))
+
+
+def _expected_hourly_points(day: date) -> int:
+    tz = dt_util.get_time_zone(TIMEZONE)
+    start = datetime(day.year, day.month, day.day, tzinfo=tz)
+    nxt = start + timedelta(days=1)
+    return round((nxt.timestamp() - start.timestamp()) / 3600)
+
+
+def _need_retry(dataset: dict | None, target_day: date) -> bool:
+    if not dataset:
+        return True
+    expected = _expected_hourly_points(target_day)
+    for data_type in [CONF_CONSUMED, CONF_RETURNED]:
+        if len(dataset.get(ENERGY_TYPE_MAP[data_type], {})) < expected:
+            return True
+    return False
 
 
 def _entry_objects(entry: ESOConfigEntry) -> list[dict]:
@@ -161,62 +205,97 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
     """Set up ESO from a config entry."""
-    if not entry.data.get(CONF_IMAP):
-        raise ConfigEntryAuthFailed(
-            "A mailbox (IMAP) is required for ESO two-factor login but is not configured."
-            "Please reconfigure the integration."
+    provider = entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER)
+
+    if provider == PROVIDER_IGNITIS:
+        client: ESOClient | IgnitisClient = IgnitisClient(
+            username=entry.data[CONF_USERNAME],
+            password=entry.data[CONF_PASSWORD],
+        )
+    else:
+        if not entry.data.get(CONF_IMAP):
+            raise ConfigEntryAuthFailed(
+                "A mailbox (IMAP) is required for ESO two-factor login but is not configured."
+                "Please reconfigure the integration."
+            )
+
+        imap_config_data = entry.data.get(CONF_IMAP)
+        imap_config = {
+            "host": imap_config_data[CONF_IMAP_HOST],
+            "port": imap_config_data[CONF_IMAP_PORT],
+            "username": imap_config_data[CONF_USERNAME],
+            "password": imap_config_data[CONF_PASSWORD],
+            "sender": imap_config_data.get(CONF_IMAP_SENDER, DEFAULT_IMAP_SENDER),
+            "folder": imap_config_data.get(CONF_IMAP_FOLDER, DEFAULT_IMAP_FOLDER),
+        }
+
+        client = ESOClient(
+            username=entry.data[CONF_USERNAME],
+            password=entry.data[CONF_PASSWORD],
+            imap_config=imap_config,
+            session_file=hass.config.path(SESSION_FILE),
         )
 
-    imap_config_data = entry.data.get(CONF_IMAP)
-    imap_config = {
-        "host": imap_config_data[CONF_IMAP_HOST],
-        "port": imap_config_data[CONF_IMAP_PORT],
-        "username": imap_config_data[CONF_USERNAME],
-        "password": imap_config_data[CONF_PASSWORD],
-        "sender": imap_config_data.get(CONF_IMAP_SENDER, DEFAULT_IMAP_SENDER),
-        "folder": imap_config_data.get(CONF_IMAP_FOLDER, DEFAULT_IMAP_FOLDER),
-    }
-
-    client = ESOClient(
-        username=entry.data[CONF_USERNAME],
-        password=entry.data[CONF_PASSWORD],
-        imap_config=imap_config,
-        session_file=hass.config.path(SESSION_FILE),
+    retry_delay = (
+        IGNITIS_RETRY_DELAY_SECONDS
+        if provider == PROVIDER_IGNITIS
+        else RETRY_DELAY_SECONDS
     )
+    max_retries = IGNITIS_MAX_RETRIES if provider == PROVIDER_IGNITIS else 1
 
-    async def async_import_generation(now: datetime, retry: bool = False) -> None:
+    async def async_import_generation(now: datetime, retry: int = 0) -> None:
         if hass.is_stopping:
             _LOGGER.debug("HA is stopping, skipping generation import")
             return
         objects = _entry_objects(entry)
         all_failed = False
+        auth_failed = False
         try:
-            _LOGGER.info("Logging in to ESO...")
+            _LOGGER.info("Logging in to %s...", provider.upper())
             await hass.async_add_executor_job(client.login)
+        except ESOAuthError as err:
+            _LOGGER.error("Authentication failed: %s. Reconfigure the integration to update credentials.", err)
+            auth_failed = True
         except Exception as err:
             _LOGGER.error("ESO login error: %s", err)
             all_failed = True
-        for obj in objects:
+        for obj in objects if not auth_failed else []:
             _LOGGER.info("Fetching ESO dataset [%s]", obj[CONF_NAME])
             try:
                 await hass.async_add_executor_job(client.fetch_dataset, obj[CONF_ID], now)
+            except ESOAuthError as err:
+                _LOGGER.error("Authentication failed for %s: %s. Reconfigure the integration to update credentials.", obj[CONF_NAME], err)
+                auth_failed = True
+                break
             except Exception as err:
                 _LOGGER.error("ESO fetch dataset error [%s]: %s", obj[CONF_NAME], err)
                 all_failed = True
                 continue
             dataset = client.get_dataset(obj[CONF_ID])
+            target_day = (now - timedelta(days=1)).date()
+            if provider == PROVIDER_IGNITIS and _need_retry(dataset, target_day):
+                _LOGGER.warning("Received incomplete data for %s, will retry later", obj[CONF_NAME])
+                all_failed = True
+                continue
             await async_insert_statistics(hass, obj, dataset)
             if obj.get(CONF_PRICE_ENTITY):
                 await async_insert_cost_statistics(hass, obj, dataset)
+            elif obj.get(CONF_FIXED_PRICE) is not None:
+                await async_insert_fixed_price_cost_statistics(hass, obj, dataset)
+            if obj.get(CONF_EXPORT_BALANCE):
+                await async_insert_export_balance_statistics(hass, obj, dataset)
             _LOGGER.info("Import completed for %s", obj[CONF_NAME])
-        if all_failed and not retry:
-            _LOGGER.warning("Fetch failed, will retry later")
+        if auth_failed:
+            return
+        if all_failed and retry < max_retries:
+            retry_at = dt_util.now() + timedelta(seconds=retry_delay)
+            _LOGGER.warning("Fetch failed, will retry at %s (attempt %d/%d)", retry_at.isoformat(), retry + 1, max_retries)
 
             async def _retry(_now: datetime) -> None:
-                await async_import_generation(datetime.now(), retry=True)
+                await async_import_generation(now, retry=retry + 1)
 
-            entry.async_on_unload(async_call_later(hass, RETRY_DELAY_SECONDS, _retry))
-        elif all_failed and retry:
+            entry.async_on_unload(async_call_later(hass, retry_delay, _retry))
+        elif all_failed:
             _LOGGER.error("Fetch failed, postponing fetch for next day")
 
     daily_import_cancel = None
@@ -225,13 +304,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
         nonlocal daily_import_cancel
         if daily_import_cancel:
             daily_import_cancel()
-        next_run = _random_daily_import_time(now)
+        next_run = _next_import_time(now, provider)
         daily_import_cancel = async_track_point_in_time(
             hass,
             async_run_scheduled_import,
             next_run,
         )
-        _LOGGER.info("Next ESO import scheduled for %s", next_run.isoformat())
+        _LOGGER.info("Next daily ESO import scheduled for %s", next_run.isoformat())
 
     async def async_run_scheduled_import(now: datetime) -> None:
         nonlocal daily_import_cancel
@@ -272,9 +351,14 @@ def _async_register_services(hass: HomeAssistant) -> None:
             targets = [entry.runtime_data.async_import for entry in entries]
         if not targets:
             raise ServiceValidationError("No ESO accounts are configured")
-        _LOGGER.info("ESO: on-demand import requested for %d account(s)", len(targets))
+        reference = call.data.get(ATTR_DATE)
+        if reference is None:
+            reference = dt_util.now()
+        elif reference.tzinfo is None:
+            reference = reference.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        _LOGGER.info("ESO: on-demand import requested for %d account(s) as of %s", len(targets), reference.isoformat())
         for callback in targets:
-            await callback(datetime.now())
+            await callback(reference)
 
     hass.services.async_register(
         DOMAIN,
@@ -339,7 +423,7 @@ async def _async_get_statistics(
     sum_ = None
     for ts, kwh in generation_data.items():
         dt_object = datetime.fromtimestamp(ts).replace(
-            tzinfo=dt_util.get_time_zone("Europe/Vilnius")
+            tzinfo=dt_util.get_time_zone(TIMEZONE)
         )
         if sum_ is None:
             sum_ = await get_previous_sum(hass, metadata, dt_object)
@@ -398,49 +482,125 @@ async def async_insert_cost_statistics(
 ) -> None:
     if obj.get(CONF_CONSUMED) is False:
         return
-    cons_dataset = consumption_dataset[ENERGY_TYPE_MAP[CONF_CONSUMED]]
-    start_time = datetime.fromtimestamp(min(cons_dataset.keys())).replace(
-        tzinfo=dt_util.get_time_zone("Europe/Vilnius")
+    series = consumption_dataset.get(ENERGY_TYPE_MAP[CONF_CONSUMED])
+    if not series:
+        return
+    start_time = datetime.fromtimestamp(min(series.keys())).replace(
+        tzinfo=dt_util.get_time_zone(TIMEZONE)
     )
-    end_time = datetime.fromtimestamp(max(cons_dataset.keys())).replace(
-        tzinfo=dt_util.get_time_zone("Europe/Vilnius")
+    end_time = datetime.fromtimestamp(max(series.keys())).replace(
+        tzinfo=dt_util.get_time_zone(TIMEZONE)
     )
     prices = await _async_generate_price_dict(hass, obj, start_time, end_time)
-    if prices is None:
+
+    def price_for(ts: float) -> float:
+        return prices.get(ts, 0)
+
+    await _async_insert_cost_series(
+        hass,
+        obj,
+        f"{DOMAIN}:energy_{CONF_COST}_{obj[CONF_ID]}",
+        f"{obj[CONF_NAME]} ({CONF_COST})",
+        series,
+        price_for,
+    )
+
+
+async def async_insert_fixed_price_cost_statistics(
+    hass: HomeAssistant,
+    obj: dict,
+    consumption_dataset: dict,
+) -> None:
+    fixed_price = obj.get(CONF_FIXED_PRICE)
+    if fixed_price is None:
         return
+
+    def price_for(ts: float) -> float:
+        return fixed_price
+
+    for data_type in [CONF_CONSUMED, CONF_RETURNED]:
+        if obj.get(data_type) is False:
+            continue
+        series = consumption_dataset.get(ENERGY_TYPE_MAP[data_type])
+        if not series:
+            continue
+        await _async_insert_cost_series(
+            hass,
+            obj,
+            f"{DOMAIN}:energy_{CONF_COST}_{data_type}_{obj[CONF_ID]}",
+            f"{obj[CONF_NAME]} {data_type} ({CONF_COST})",
+            series,
+            price_for,
+        )
+
+
+async def _async_insert_cost_series(
+    hass: HomeAssistant,
+    obj: dict,
+    statistic_id: str,
+    name: str,
+    series: dict,
+    price_for: Callable[[float], float],
+) -> None:
     cost_metadata = StatisticMetaData(
         has_sum=True,
         mean_type=StatisticMeanType.NONE,
-        name=f"{obj[CONF_NAME]} ({CONF_COST})",
+        name=name,
         source=DOMAIN,
-        statistic_id=f"{DOMAIN}:energy_{CONF_COST}_{obj[CONF_ID]}",
+        statistic_id=statistic_id,
         unit_of_measurement=obj.get(CONF_PRICE_CURRENCY, DEFAULT_PRICE_CURRENCY),
         unit_class=None,
     )
     cost_stats: list[StatisticData] = []
     cost_sum_ = None
-    for ts, cons_kwh in cons_dataset.items():
+    for ts, kwh in series.items():
         dt_object = datetime.fromtimestamp(ts).replace(
-            tzinfo=dt_util.get_time_zone("Europe/Vilnius")
+            tzinfo=dt_util.get_time_zone(TIMEZONE)
         )
-        price = prices.get(ts, 0)
-        cost = round(cons_kwh * price, 5)
+        cost = round(kwh * price_for(ts), 5)
         if cost_sum_ is None:
-            cost_sum_ = await get_previous_sum(hass, cost_metadata, start_time)
+            cost_sum_ = await get_previous_sum(hass, cost_metadata, dt_object)
         cost_sum_ += cost
-        cost_stats.append(
-            StatisticData(
-                start=dt_object,
-                state=cost,
-                sum=cost_sum_,
-            )
-        )
+        cost_stats.append(StatisticData(start=dt_object, state=cost, sum=cost_sum_))
     _LOGGER.debug(
         "Generated cost statistics for %s: %s",
-        f"{DOMAIN}:energy_{CONF_COST}_{obj[CONF_ID]}",
+        statistic_id,
         cost_stats,
     )
     async_add_external_statistics(hass, cost_metadata, cost_stats)
+
+
+async def async_insert_export_balance_statistics(
+    hass: HomeAssistant,
+    obj: dict,
+    consumption_dataset: dict,
+) -> None:
+    balance = consumption_dataset.get(EXPORT_BALANCE_KEY) if consumption_dataset else None
+    if balance is None:
+        _LOGGER.warning("Received empty export balance data for %s", obj[CONF_NAME])
+        return
+    statistic_id = f"{DOMAIN}:energy_{CONF_EXPORT_BALANCE}_{obj[CONF_ID]}"
+    metadata = StatisticMetaData(
+        has_sum=True,
+        mean_type=StatisticMeanType.NONE,
+        name=f"{obj[CONF_NAME]} ({CONF_EXPORT_BALANCE})",
+        source=DOMAIN,
+        statistic_id=statistic_id,
+        unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        unit_class="energy",
+    )
+    tz = dt_util.get_time_zone(TIMEZONE)
+    timestamps = list(consumption_dataset.get(ENERGY_TYPE_MAP[CONF_CONSUMED], {}))
+    timestamps += list(consumption_dataset.get(ENERGY_TYPE_MAP[CONF_RETURNED], {}))
+    if timestamps:
+        start = datetime.fromtimestamp(max(timestamps)).replace(tzinfo=tz)
+    else:
+        start = datetime.now(tz=tz).replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(hours=1)
+    statistics = [StatisticData(start=start, state=balance, sum=balance)]
+    _LOGGER.debug("Generated export balance statistics for %s: %s", statistic_id, statistics)
+    async_add_external_statistics(hass, metadata, statistics)
 
 
 async def _async_generate_price_dict(

--- a/custom_components/eso/config_flow.py
+++ b/custom_components/eso/config_flow.py
@@ -23,6 +23,8 @@ from homeassistant.helpers import selector
 
 from .const import (
     CONF_CONSUMED,
+    CONF_EXPORT_BALANCE,
+    CONF_FIXED_PRICE,
     CONF_IMAP,
     CONF_IMAP_FOLDER,
     CONF_IMAP_HOST,
@@ -31,13 +33,18 @@ from .const import (
     CONF_OBJECTS,
     CONF_PRICE_CURRENCY,
     CONF_PRICE_ENTITY,
+    CONF_PROVIDER,
     CONF_RETURNED,
     DEFAULT_IMAP_FOLDER,
     DEFAULT_IMAP_HOST,
     DEFAULT_IMAP_PORT,
     DEFAULT_IMAP_SENDER,
     DEFAULT_PRICE_CURRENCY,
+    DEFAULT_PROVIDER,
     DOMAIN,
+    PROVIDER_ESO,
+    PROVIDER_IGNITIS,
+    PROVIDERS,
     SESSION_FILE,
     SUBENTRY_TYPE_OBJECT,
 )
@@ -47,6 +54,7 @@ from .eso_client import (
     ESOConnectionError,
     ESOError,
 )
+from .ignitis_client import IgnitisClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,6 +122,39 @@ def _runtime_imap(imap: dict | None) -> dict | None:
     }
 
 
+def _provider_selector() -> selector.SelectSelector:
+    """A translatable dropdown of the available data providers."""
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=PROVIDERS,
+            translation_key=CONF_PROVIDER,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    )
+
+
+def _make_client(
+    hass, provider: str, username: str, password: str, imap: dict | None = None
+) -> ESOClient | IgnitisClient:
+    """Build the data-provider client for validation and object discovery."""
+    if provider == PROVIDER_IGNITIS:
+        return IgnitisClient(username=username, password=password)
+    return ESOClient(
+        username=username,
+        password=password,
+        imap_config=_runtime_imap(imap),
+        session_file=hass.config.path(SESSION_FILE),
+    )
+
+
+def _unique_id(provider: str, username: str) -> str:
+    """Namespace the unique id per provider so the same email can be used on
+    both providers. ESO keeps the bare username for backward compatibility."""
+    if provider == PROVIDER_ESO:
+        return username.lower()
+    return f"{provider}:{username.lower()}"
+
+
 def _settings_schema(defaults: dict) -> vol.Schema:
     """Schema for a single object's settings (used for add & reconfigure)."""
     return vol.Schema(
@@ -135,6 +176,15 @@ def _settings_schema(defaults: dict) -> vol.Schema:
                 CONF_PRICE_CURRENCY,
                 default=defaults.get(CONF_PRICE_CURRENCY, DEFAULT_PRICE_CURRENCY),
             ): str,
+            vol.Optional(
+                CONF_FIXED_PRICE,
+                description={"suggested_value": defaults.get(CONF_FIXED_PRICE)},
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(mode="box", step="any")
+            ),
+            vol.Required(
+                CONF_EXPORT_BALANCE, default=defaults.get(CONF_EXPORT_BALANCE, False)
+            ): bool,
         }
     )
 
@@ -147,10 +197,14 @@ def _object_from_settings(obj_id: str, name: str, user_input: dict) -> dict:
         CONF_CONSUMED: user_input[CONF_CONSUMED],
         CONF_RETURNED: user_input[CONF_RETURNED],
         CONF_PRICE_CURRENCY: user_input[CONF_PRICE_CURRENCY],
+        CONF_EXPORT_BALANCE: user_input.get(CONF_EXPORT_BALANCE, False),
     }
     price_entity = user_input.get(CONF_PRICE_ENTITY)
     if price_entity:
         obj[CONF_PRICE_ENTITY] = price_entity
+    fixed_price = user_input.get(CONF_FIXED_PRICE)
+    if fixed_price is not None:
+        obj[CONF_FIXED_PRICE] = fixed_price
     return obj
 
 
@@ -170,24 +224,30 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
     def __init__(self) -> None:
+        self._provider: str = DEFAULT_PROVIDER
         self._username: str | None = None
         self._password: str | None = None
         self._imap: dict | None = None
         self._discovered: list[dict] = []
         self._reauth_entry: ConfigEntry | None = None
 
-    # ---- step 1: ESO credentials ------------------------------------------
+    # ---- step 1: provider + credentials -----------------------------------
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         if user_input is not None:
+            self._provider = user_input[CONF_PROVIDER]
             self._username = user_input[CONF_USERNAME]
             self._password = user_input[CONF_PASSWORD]
-            await self.async_set_unique_id(self._username.lower())
+            await self.async_set_unique_id(
+                _unique_id(self._provider, self._username)
+            )
             self._abort_if_unique_id_configured()
-            client = ESOClient(username=self._username, password=self._password)
+            client = _make_client(
+                self.hass, self._provider, self._username, self._password
+            )
             try:
                 valid = await self.hass.async_add_executor_job(client.check_password)
             except ESOConnectionError:
@@ -196,11 +256,17 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 if valid:
+                    if self._provider == PROVIDER_IGNITIS:
+                        return await self.async_step_objects()
                     return await self.async_step_imap()
                 errors["base"] = "invalid_auth"
 
         schema = vol.Schema(
-            {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+            {
+                vol.Required(CONF_PROVIDER, default=DEFAULT_PROVIDER): _provider_selector(),
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
         )
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
@@ -229,11 +295,12 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         if not self._discovered:
-            client = ESOClient(
-                username=self._username,
-                password=self._password,
-                imap_config=_runtime_imap(self._imap),
-                session_file=self.hass.config.path(SESSION_FILE),
+            client = _make_client(
+                self.hass,
+                self._provider,
+                self._username,
+                self._password,
+                self._imap,
             )
             try:
                 self._discovered = await self.hass.async_add_executor_job(
@@ -247,6 +314,18 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             if errors:
                 # Let the user revisit the IMAP step and retry.
+                if self._provider == PROVIDER_IGNITIS:
+                    return self.async_show_form(
+                        step_id="user",
+                        data_schema=vol.Schema(
+                            {
+                                vol.Required(CONF_PROVIDER, default=self._provider): _provider_selector(),
+                                vol.Required(CONF_USERNAME, default=self._username): str,
+                                vol.Required(CONF_PASSWORD): str,
+                            }
+                        ),
+                        errors=errors,
+                    )
                 return self.async_show_form(
                     step_id="imap", data_schema=_imap_schema(), errors=errors
                 )
@@ -274,10 +353,12 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
                     if obj[CONF_ID] in selected
                 ]
                 data: dict[str, Any] = {
+                    CONF_PROVIDER: self._provider,
                     CONF_USERNAME: self._username,
                     CONF_PASSWORD: self._password,
-                    CONF_IMAP: self._imap,
                 }
+                if self._provider == PROVIDER_ESO:
+                    data[CONF_IMAP] = self._imap
                 return self.async_create_entry(
                     title=self._username, data=data, subentries=subentries
                 )
@@ -297,15 +378,17 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         username = import_data[CONF_USERNAME]
-        await self.async_set_unique_id(username.lower())
+        provider = import_data.get(CONF_PROVIDER, DEFAULT_PROVIDER)
+        await self.async_set_unique_id(_unique_id(provider, username))
         self._abort_if_unique_id_configured()
 
         data: dict[str, Any] = {
+            CONF_PROVIDER: provider,
             CONF_USERNAME: username,
             CONF_PASSWORD: import_data[CONF_PASSWORD],
         }
         imap = import_data.get(CONF_IMAP)
-        if imap:
+        if imap and provider == PROVIDER_ESO:
             data[CONF_IMAP] = {
                 CONF_USERNAME: imap[CONF_USERNAME],
                 CONF_PASSWORD: imap[CONF_PASSWORD],
@@ -325,9 +408,12 @@ class ESOConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_PRICE_CURRENCY: obj.get(
                     CONF_PRICE_CURRENCY, DEFAULT_PRICE_CURRENCY
                 ),
+                CONF_EXPORT_BALANCE: obj.get(CONF_EXPORT_BALANCE, False),
             }
             if obj.get(CONF_PRICE_ENTITY):
                 entry[CONF_PRICE_ENTITY] = obj[CONF_PRICE_ENTITY]
+            if obj.get(CONF_FIXED_PRICE) is not None:
+                entry[CONF_FIXED_PRICE] = obj[CONF_FIXED_PRICE]
             subentries.append(_object_subentry(entry))
 
         return self.async_create_entry(
@@ -424,17 +510,17 @@ class ESOOptionsFlow(OptionsFlow):
     ) -> ConfigFlowResult:
         errors: dict[str, str] = {}
         data = self.config_entry.data
+        provider = data.get(CONF_PROVIDER, DEFAULT_PROVIDER)
         imap = data.get(CONF_IMAP) or {}
+        is_eso = provider == PROVIDER_ESO
 
         if user_input is not None:
             username = data[CONF_USERNAME]
             password = user_input[CONF_PASSWORD]
-            if not user_input.get(CONF_IMAP_USERNAME) or not user_input.get(
-                CONF_IMAP_PASSWORD
-            ):
+            if is_eso and (not user_input.get(CONF_IMAP_USERNAME) or not user_input.get(CONF_IMAP_PASSWORD)):
                 errors["base"] = "imap_required"
             else:
-                client = ESOClient(username=username, password=password)
+                client = _make_client(self.hass, provider, username, password)
                 try:
                     valid = await self.hass.async_add_executor_job(
                         client.check_password
@@ -447,30 +533,34 @@ class ESOOptionsFlow(OptionsFlow):
                     if not valid:
                         errors["base"] = "invalid_auth"
             if not errors:
+                new_data: dict[str, Any] = {
+                    CONF_PROVIDER: provider,
+                    CONF_USERNAME: username,
+                    CONF_PASSWORD: password,
+                }
+                if is_eso:
+                    new_data[CONF_IMAP] = _build_imap_config(user_input)
                 self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data={
-                        CONF_USERNAME: username,
-                        CONF_PASSWORD: password,
-                        CONF_IMAP: _build_imap_config(user_input),
-                    },
+                    self.config_entry, data=new_data
                 )
                 return self.async_create_entry(data={})
 
         schema = vol.Schema(
             {vol.Required(CONF_PASSWORD, default=data.get(CONF_PASSWORD)): str}
-        ).extend(
-            _imap_schema(
-                {
-                    CONF_IMAP_USERNAME: imap.get(CONF_USERNAME, ""),
-                    CONF_IMAP_PASSWORD: imap.get(CONF_PASSWORD, ""),
-                    CONF_IMAP_HOST: imap.get(CONF_IMAP_HOST, DEFAULT_IMAP_HOST),
-                    CONF_IMAP_PORT: imap.get(CONF_IMAP_PORT, DEFAULT_IMAP_PORT),
-                    CONF_IMAP_SENDER: imap.get(CONF_IMAP_SENDER, DEFAULT_IMAP_SENDER),
-                    CONF_IMAP_FOLDER: imap.get(CONF_IMAP_FOLDER, DEFAULT_IMAP_FOLDER),
-                }
-            ).schema
         )
+        if is_eso:
+            schema = schema.extend(
+                _imap_schema(
+                    {
+                        CONF_IMAP_USERNAME: imap.get(CONF_USERNAME, ""),
+                        CONF_IMAP_PASSWORD: imap.get(CONF_PASSWORD, ""),
+                        CONF_IMAP_HOST: imap.get(CONF_IMAP_HOST, DEFAULT_IMAP_HOST),
+                        CONF_IMAP_PORT: imap.get(CONF_IMAP_PORT, DEFAULT_IMAP_PORT),
+                        CONF_IMAP_SENDER: imap.get(CONF_IMAP_SENDER, DEFAULT_IMAP_SENDER),
+                        CONF_IMAP_FOLDER: imap.get(CONF_IMAP_FOLDER, DEFAULT_IMAP_FOLDER),
+                    }
+                ).schema
+            )
         return self.async_show_form(
             step_id="init",
             data_schema=schema,
@@ -495,11 +585,12 @@ class ESOObjectSubentryFlow(ConfigSubentryFlow):
         entry = self._get_entry()
 
         if not self._discovered:
-            client = ESOClient(
-                username=entry.data[CONF_USERNAME],
-                password=entry.data[CONF_PASSWORD],
-                imap_config=_runtime_imap(entry.data.get(CONF_IMAP)),
-                session_file=self.hass.config.path(SESSION_FILE),
+            client = _make_client(
+                self.hass,
+                entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER),
+                entry.data[CONF_USERNAME],
+                entry.data[CONF_PASSWORD],
+                entry.data.get(CONF_IMAP),
             )
             try:
                 self._discovered = await self.hass.async_add_executor_job(

--- a/custom_components/eso/const.py
+++ b/custom_components/eso/const.py
@@ -2,6 +2,9 @@
 
 DOMAIN = "eso"
 
+# Local timezone all provider timestamps are expressed in
+TIMEZONE = "Europe/Vilnius"
+
 # Account configuration
 CONF_OBJECTS = "objects"
 CONF_CONSUMED = "consumed"
@@ -9,6 +12,15 @@ CONF_RETURNED = "returned"
 CONF_COST = "cost"
 CONF_PRICE_ENTITY = "price_entity"
 CONF_PRICE_CURRENCY = "price_currency"
+CONF_FIXED_PRICE = "fixed_price"
+CONF_EXPORT_BALANCE = "export_balance"
+
+# Data provider selection
+CONF_PROVIDER = "provider"
+PROVIDER_ESO = "eso"
+PROVIDER_IGNITIS = "ignitis"
+PROVIDERS = [PROVIDER_ESO, PROVIDER_IGNITIS]
+DEFAULT_PROVIDER = PROVIDER_ESO
 
 # IMAP (two-factor) configuration
 CONF_IMAP = "imap"
@@ -35,9 +47,25 @@ ENERGY_TYPE_MAP = {
     CONF_CONSUMED: POWER_CONSUMED,
     CONF_RETURNED: POWER_RETURNED,
 }
+# Dataset key under which a provider stores the scalar export balance (Ignitis).
+EXPORT_BALANCE_KEY = CONF_EXPORT_BALANCE
 
-# 3 hour pause between fetch retries
+# ESO daily import: random time inside a window (spreads API load and lets
+# multiple HA instances using the same account avoid colliding)
+DAILY_IMPORT_WINDOW_START_HOUR = 5
+DAILY_IMPORT_WINDOW_START_MINUTE = 10
+DAILY_IMPORT_WINDOW_SECONDS = 2 * 3600
+
+# 3 hour pause between fetch retries (ESO)
 RETRY_DELAY_SECONDS = 3 * 3600
+
+# Ignitis daily import: fixed time of day plus short data-availability retries
+# (Ignitis publishes the previous day's data during the morning, so retry a few
+# times until a full 24-hour dataset is available).
+IGNITIS_IMPORT_HOUR = 10
+IGNITIS_IMPORT_MINUTE = 30
+IGNITIS_RETRY_DELAY_SECONDS = 10 * 60
+IGNITIS_MAX_RETRIES = 10
 
 # Subentry type: one metering point (object) per subentry
 SUBENTRY_TYPE_OBJECT = "object"
@@ -45,3 +73,6 @@ SUBENTRY_TYPE_OBJECT = "object"
 # Service to trigger an on-demand import
 SERVICE_IMPORT_NOW = "import_now"
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+# Optional reference date for the import (defaults to now); use it to backfill a
+# past day. Providers import relative to this date exactly as the daily run does.
+ATTR_DATE = "date"

--- a/custom_components/eso/ignitis_client.py
+++ b/custom_components/eso/ignitis_client.py
@@ -1,0 +1,147 @@
+import logging
+from datetime import datetime, timedelta
+
+import requests
+
+from .const import EXPORT_BALANCE_KEY, POWER_CONSUMED, POWER_RETURNED
+from .eso_client import ESOAuthError, ESOConnectionError
+
+LOGIN_URL = "https://energy-smart-api.ignitis.lt/api/users/login"
+GENERATION_URL = "https://energy-smart-api.ignitis.lt/api/v2/objects/usage/{object}/day"
+_LOGGER = logging.getLogger(__name__)
+
+
+class IgnitisClient:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        imap_config: dict | None = None,
+        session_file: str | None = None,
+    ):
+        self.username: str = username
+        self.password: str = password
+        self.dataset: dict = {}
+        self.session: requests.Session = requests.Session()
+        self.token: str | None = None
+        self._objects: list[dict] = []
+
+    def login(self) -> None:
+        self.dataset = {}
+        try:
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            }
+            response = self.session.post(
+                LOGIN_URL,
+                data={
+                    "email": self.username,
+                    "password": self.password,
+                },
+                headers=headers,
+            )
+            response.raise_for_status()
+            _LOGGER.debug("Ignitis login response status: %s", response.status_code)
+        except requests.exceptions.RequestException as e:
+            _LOGGER.error("Ignitis login error: %s", e)
+            raise ESOConnectionError(str(e)) from e
+        try:
+            login_response = response.json()
+        except ValueError as e:
+            raise ESOConnectionError(f"Invalid Ignitis login response: {e}") from e
+        token = login_response.get("token")
+        if not token:
+            raise ESOAuthError("Ignitis login did not return a token")
+        self.token = token
+        self._objects = []
+        for obj in login_response.get("user", {}).get("objects", []):
+            uoid = obj.get("uoid")
+            if uoid is None:
+                continue
+            _LOGGER.info("Found object: %s, address: %s", uoid, obj.get("address"))
+            self._objects.append(
+                {"id": str(uoid), "name": obj.get("address") or str(uoid)}
+            )
+
+    # ---- config-flow helpers ----------------------------------------------
+
+    def check_password(self) -> bool:
+        try:
+            response = self.session.post(
+                LOGIN_URL,
+                data={"email": self.username, "password": self.password},
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+                },
+            )
+        except requests.exceptions.RequestException as e:
+            raise ESOConnectionError(str(e)) from e
+        if response.status_code in (401, 403):
+            return False
+        try:
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise ESOConnectionError(str(e)) from e
+        try:
+            return bool(response.json().get("token"))
+        except ValueError as e:
+            raise ESOConnectionError(f"Invalid Ignitis response: {e}") from e
+
+    def discover_objects(self) -> list[dict]:
+        self.login()
+        if not self.token:
+            raise ESOAuthError("Ignitis login did not return a token")
+        return list(self._objects)
+
+    def fetch(self, obj: str, date: datetime) -> dict:
+        headers = {
+            "X-API-KEY": self.token,
+        }
+        yesterday = date - timedelta(days=1)
+        try:
+            params = {
+                "dateFrom": yesterday.strftime("%Y-%m-%d"),
+                "dateTo": yesterday.strftime("%Y-%m-%d"),
+                "interval": "hour",
+            }
+            response = self.session.get(
+                GENERATION_URL.replace("{object}", obj),
+                params=params,
+                headers=headers,
+            )
+            if response.status_code in (401, 403):
+                raise ESOAuthError("Ignitis rejected the API token")
+            response.raise_for_status()
+            _LOGGER.debug("Got fetch response: %s", response.text)
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            _LOGGER.error("Ignitis fetch error: %s", e)
+            return {}
+
+    def fetch_dataset(self, obj: str, date: datetime) -> dict | None:
+        self.dataset[obj] = {}
+        data = self.fetch(obj, date)
+        self.dataset[obj] = self.parse_dataset(data)
+        return self.dataset[obj]
+
+    def get_dataset(self, obj: str) -> dict | None:
+        if obj not in self.dataset:
+            return None
+        return self.dataset[obj]
+
+    @staticmethod
+    def parse_dataset(dataset: dict) -> dict:
+        result: dict = {POWER_CONSUMED: {}, POWER_RETURNED: {}, EXPORT_BALANCE_KEY: None}
+        export = dataset.get("exportBalance")
+        if isinstance(export, dict) and export.get("balance") is not None:
+            result[EXPORT_BALANCE_KEY] = export["balance"]
+        for record in dataset.get("data", []):
+            try:
+                timestamp = datetime.strptime(
+                    record["startTime"], "%Y-%m-%d %H:%M:%S"
+                ).timestamp()
+                result[POWER_CONSUMED][timestamp] = record.get("consumed") or 0.0
+                result[POWER_RETURNED][timestamp] = record.get("supplied") or 0.0
+            except Exception as e:  # noqa: BLE001
+                _LOGGER.error("Failed to parse dataset record %s: %s", record, e)
+        return result

--- a/custom_components/eso/manifest.json
+++ b/custom_components/eso/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/algirdasc/hass-eso/issues",
   "requirements": ["requests"],
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/custom_components/eso/services.yaml
+++ b/custom_components/eso/services.yaml
@@ -6,3 +6,8 @@ import_now:
       selector:
         config_entry:
           integration: eso
+    date:
+      required: false
+      example: "2026-06-01 00:00:00"
+      selector:
+        datetime:

--- a/custom_components/eso/strings.json
+++ b/custom_components/eso/strings.json
@@ -2,15 +2,17 @@
   "config": {
     "step": {
       "user": {
-        "title": "ESO account",
-        "description": "Sign in with your ESO self-service account (https://mano.eso.lt). These are the same credentials you use to log in to the ESO website.",
+        "title": "Account",
+        "description": "Choose your data provider and sign in. For ESO use your mano.eso.lt credentials; for Ignitis use your Ignitis \"Energy Smart\" (energy-smart-api.ignitis.lt) credentials.",
         "data": {
+          "provider": "Data provider",
           "username": "Username / email",
           "password": "Password"
         },
         "data_description": {
-          "username": "Your ESO (mano.eso.lt) username or email address.",
-          "password": "Your ESO account password. It is verified before continuing."
+          "provider": "ESO (mano.eso.lt) uses an email two-factor code; Ignitis signs in directly without a mailbox.",
+          "username": "Your provider username or email address.",
+          "password": "Your account password. It is verified before continuing."
         }
       },
       "imap": {
@@ -133,14 +135,18 @@
             "consumed": "Track consumed energy",
             "returned": "Track returned energy",
             "price_entity": "Price entity (cost tracking)",
-            "price_currency": "Price currency"
+            "price_currency": "Price currency",
+            "fixed_price": "Fixed price per kWh",
+            "export_balance": "Track export balance (Ignitis)"
           },
           "data_description": {
             "name": "Name shown in the energy dashboard.",
             "consumed": "Generate statistics for energy consumed from the grid.",
             "returned": "Generate statistics for energy returned to the grid.",
             "price_entity": "Optional sensor tracking electricity price; enables a cost statistic.",
-            "price_currency": "Currency for the cost statistic (e.g. EUR)."
+            "price_currency": "Currency for the cost statistic (e.g. EUR).",
+            "fixed_price": "Optional flat price per kWh, used for the cost statistic when no price entity is set.",
+            "export_balance": "Track the export balance reported by Ignitis (no effect for ESO)."
           }
         },
         "reconfigure": {
@@ -151,14 +157,18 @@
             "consumed": "Track consumed energy",
             "returned": "Track returned energy",
             "price_entity": "Price entity (cost tracking)",
-            "price_currency": "Price currency"
+            "price_currency": "Price currency",
+            "fixed_price": "Fixed price per kWh",
+            "export_balance": "Track export balance (Ignitis)"
           },
           "data_description": {
             "name": "Name shown in the energy dashboard.",
             "consumed": "Generate statistics for energy consumed from the grid.",
             "returned": "Generate statistics for energy returned to the grid.",
             "price_entity": "Optional sensor tracking electricity price; enables a cost statistic.",
-            "price_currency": "Currency for the cost statistic (e.g. EUR)."
+            "price_currency": "Currency for the cost statistic (e.g. EUR).",
+            "fixed_price": "Optional flat price per kWh, used for the cost statistic when no price entity is set.",
+            "export_balance": "Track the export balance reported by Ignitis (no effect for ESO)."
           }
         }
       },
@@ -179,6 +189,10 @@
         "config_entry_id": {
           "name": "ESO account",
           "description": "The ESO account(s) to import. Leave empty to import all configured accounts."
+        },
+        "date": {
+          "name": "Date",
+          "description": "Optional reference date to import (defaults to now); use it to backfill a past day. The day imported is relative to this date exactly as the daily run is: for Ignitis the previous day is fetched."
         }
       }
     }
@@ -193,6 +207,14 @@
             "description": "Configuring ESO via configuration.yaml is deprecated. Your existing configuration has been imported and the integration is now available under Settings \u2192 Devices & Services.\n\nRemove the `eso:` block from configuration.yaml and restart Home Assistant, then submit to dismiss this issue."
           }
         }
+      }
+    }
+  },
+  "selector": {
+    "provider": {
+      "options": {
+        "eso": "ESO",
+        "ignitis": "Ignitis"
       }
     }
   }

--- a/custom_components/eso/translations/en.json
+++ b/custom_components/eso/translations/en.json
@@ -2,15 +2,17 @@
   "config": {
     "step": {
       "user": {
-        "title": "ESO account",
-        "description": "Sign in with your ESO self-service account (https://mano.eso.lt). These are the same credentials you use to log in to the ESO website.",
+        "title": "Account",
+        "description": "Choose your data provider and sign in. For ESO use your mano.eso.lt credentials; for Ignitis use your Ignitis \"Energy Smart\" (energy-smart-api.ignitis.lt) credentials.",
         "data": {
+          "provider": "Data provider",
           "username": "Username / email",
           "password": "Password"
         },
         "data_description": {
-          "username": "Your ESO (mano.eso.lt) username or email address.",
-          "password": "Your ESO account password. It is verified before continuing."
+          "provider": "ESO (mano.eso.lt) uses an email two-factor code; Ignitis signs in directly without a mailbox.",
+          "username": "Your provider username or email address.",
+          "password": "Your account password. It is verified before continuing."
         }
       },
       "imap": {
@@ -133,14 +135,18 @@
             "consumed": "Track consumed energy",
             "returned": "Track returned energy",
             "price_entity": "Price entity (cost tracking)",
-            "price_currency": "Price currency"
+            "price_currency": "Price currency",
+            "fixed_price": "Fixed price per kWh",
+            "export_balance": "Track export balance (Ignitis)"
           },
           "data_description": {
             "name": "Name shown in the energy dashboard.",
             "consumed": "Generate statistics for energy consumed from the grid.",
             "returned": "Generate statistics for energy returned to the grid.",
             "price_entity": "Optional sensor tracking electricity price; enables a cost statistic.",
-            "price_currency": "Currency for the cost statistic (e.g. EUR)."
+            "price_currency": "Currency for the cost statistic (e.g. EUR).",
+            "fixed_price": "Optional flat price per kWh, used for the cost statistic when no price entity is set.",
+            "export_balance": "Track the export balance reported by Ignitis (no effect for ESO)."
           }
         },
         "reconfigure": {
@@ -151,14 +157,18 @@
             "consumed": "Track consumed energy",
             "returned": "Track returned energy",
             "price_entity": "Price entity (cost tracking)",
-            "price_currency": "Price currency"
+            "price_currency": "Price currency",
+            "fixed_price": "Fixed price per kWh",
+            "export_balance": "Track export balance (Ignitis)"
           },
           "data_description": {
             "name": "Name shown in the energy dashboard.",
             "consumed": "Generate statistics for energy consumed from the grid.",
             "returned": "Generate statistics for energy returned to the grid.",
             "price_entity": "Optional sensor tracking electricity price; enables a cost statistic.",
-            "price_currency": "Currency for the cost statistic (e.g. EUR)."
+            "price_currency": "Currency for the cost statistic (e.g. EUR).",
+            "fixed_price": "Optional flat price per kWh, used for the cost statistic when no price entity is set.",
+            "export_balance": "Track the export balance reported by Ignitis (no effect for ESO)."
           }
         }
       },
@@ -179,6 +189,10 @@
         "config_entry_id": {
           "name": "ESO account",
           "description": "The ESO account(s) to import. Leave empty to import all configured accounts."
+        },
+        "date": {
+          "name": "Date",
+          "description": "Optional reference date to import (defaults to now); use it to backfill a past day. The day imported is relative to this date exactly as the daily run is: for Ignitis the previous day is fetched."
         }
       }
     }
@@ -193,6 +207,14 @@
             "description": "Configuring ESO via configuration.yaml is deprecated. Your existing configuration has been imported and the integration is now available under Settings \u2192 Devices & Services.\n\nRemove the `eso:` block from configuration.yaml and restart Home Assistant, then submit to dismiss this issue."
           }
         }
+      }
+    }
+  },
+  "selector": {
+    "provider": {
+      "options": {
+        "eso": "ESO",
+        "ignitis": "Ignitis"
       }
     }
   }


### PR DESCRIPTION
Ignitis data provider
You can now choose Ignitis as your data provider when setting up the integration, as an alternative to ESO.

Pick Ignitis on the first setup screen and sign in with your Ignitis "Energy Smart" app credentials — the same email and password you use in the Energy Smart app. It signs in directly. It then finds the metering points on your account and lets you choose which to track.

Once configured, it runs every morning at 10:30 and imports the previous day's hourly consumption and generation. If that day isn't fully published yet, it retries every 10 minutes for a while until the complete data is available.

Per metering point you can also enable your export balance (the accumulated net-metering amount Ignitis tracks) and a fixed per-kWh cost estimate.

Everything flows into the same statistics as ESO, so it works exactly the same from there on.