### PR TITLE
Add date_from/date_to backfill support to the import_now service

### DIFF
--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -33,6 +33,8 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_CONFIG_ENTRY_ID,
+    ATTR_DATE_FROM,
+    ATTR_DATE_TO,
     CONF_CONSUMED,
     CONF_COST,
     CONF_IMAP,
@@ -110,7 +112,11 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 SERVICE_IMPORT_NOW_SCHEMA = vol.Schema(
-    {vol.Optional(ATTR_CONFIG_ENTRY_ID): vol.All(cv.ensure_list, [cv.string])}
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_DATE_FROM): cv.date,
+        vol.Optional(ATTR_DATE_TO): cv.date,
+    }
 )
 
 
@@ -184,7 +190,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
         session_file=hass.config.path(SESSION_FILE),
     )
 
-    async def async_import_generation(now: datetime, retry: bool = False) -> None:
+    async def async_import_generation(
+        now: datetime,
+        retry: bool = False,
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
+    ) -> None:
         if hass.is_stopping:
             _LOGGER.debug("HA is stopping, skipping generation import")
             return
@@ -199,7 +210,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
         for obj in objects:
             _LOGGER.info("Fetching ESO dataset [%s]", obj[CONF_NAME])
             try:
-                await hass.async_add_executor_job(client.fetch_dataset, obj[CONF_ID], now)
+                if date_from is not None:
+                    await hass.async_add_executor_job(
+                        client.fetch_dataset_range,
+                        obj[CONF_ID],
+                        date_from,
+                        date_to or now,
+                    )
+                else:
+                    await hass.async_add_executor_job(client.fetch_dataset, obj[CONF_ID], now)
             except Exception as err:
                 _LOGGER.error("ESO fetch dataset error [%s]: %s", obj[CONF_NAME], err)
                 all_failed = True
@@ -209,7 +228,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
             if obj.get(CONF_PRICE_ENTITY):
                 await async_insert_cost_statistics(hass, obj, dataset)
             _LOGGER.info("Import completed for %s", obj[CONF_NAME])
-        if all_failed and not retry:
+        # Range (backfill) imports are user-invoked one-offs — no silent retry.
+        if all_failed and not retry and date_from is None:
             _LOGGER.warning("Fetch failed, will retry later")
 
             async def _retry(_now: datetime) -> None:
@@ -272,9 +292,23 @@ def _async_register_services(hass: HomeAssistant) -> None:
             targets = [entry.runtime_data.async_import for entry in entries]
         if not targets:
             raise ServiceValidationError("No ESO accounts are configured")
+        date_from = call.data.get(ATTR_DATE_FROM)
+        date_to = call.data.get(ATTR_DATE_TO)
+        if date_to and not date_from:
+            raise ServiceValidationError("date_to requires date_from")
+        if date_from and date_to and date_from > date_to:
+            raise ServiceValidationError("date_from must not be after date_to")
+        kwargs = {}
+        if date_from:
+            kwargs = {
+                "date_from": datetime.combine(date_from, datetime.min.time()),
+                "date_to": datetime.combine(date_to, datetime.min.time())
+                if date_to
+                else None,
+            }
         _LOGGER.info("ESO: on-demand import requested for %d account(s)", len(targets))
         for callback in targets:
-            await callback(datetime.now())
+            await callback(datetime.now(), **kwargs)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -314,8 +314,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
                 await async_import_generation(now, retry=retry + 1)
 
             entry.async_on_unload(async_call_later(hass, retry_delay, _retry))
-        elif all_failed:
+        elif all_failed and date_from is None:
             _LOGGER.error("Fetch failed, postponing fetch for next day")
+        elif all_failed:
+            _LOGGER.error("Backfill import failed")
 
     daily_import_cancel = None
 

--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -365,9 +365,10 @@ def _async_register_services(hass: HomeAssistant) -> None:
                 raise ServiceValidationError(
                     f"Unknown ESO config entry id(s): {', '.join(unknown)}"
                 )
-            targets = [by_id[eid].runtime_data.async_import for eid in entry_ids]
+            target_entries = [by_id[eid] for eid in entry_ids]
         else:
-            targets = [entry.runtime_data.async_import for entry in entries]
+            target_entries = entries
+        targets = [entry.runtime_data.async_import for entry in target_entries]
         if not targets:
             raise ServiceValidationError("No ESO accounts are configured")
         date_from = call.data.get(ATTR_DATE_FROM)
@@ -378,9 +379,20 @@ def _async_register_services(hass: HomeAssistant) -> None:
             raise ServiceValidationError("date_from must not be after date_to")
         kwargs = {}
         if date_from:
+            if any(
+                entry.data.get(CONF_PROVIDER, DEFAULT_PROVIDER) == PROVIDER_IGNITIS
+                for entry in target_entries
+            ):
+                raise ServiceValidationError(
+                    "Backfill (date_from/date_to) is not supported for Ignitis accounts"
+                )
             kwargs = {
-                "date_from": datetime.combine(date_from, datetime.min.time()),
-                "date_to": datetime.combine(date_to, datetime.min.time())
+                "date_from": datetime.combine(
+                    date_from, datetime.min.time(), tzinfo=dt_util.DEFAULT_TIME_ZONE
+                ),
+                "date_to": datetime.combine(
+                    date_to, datetime.min.time(), tzinfo=dt_util.DEFAULT_TIME_ZONE
+                )
                 if date_to
                 else None,
             }

--- a/custom_components/eso/const.py
+++ b/custom_components/eso/const.py
@@ -45,3 +45,5 @@ SUBENTRY_TYPE_OBJECT = "object"
 # Service to trigger an on-demand import
 SERVICE_IMPORT_NOW = "import_now"
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_DATE_FROM = "date_from"
+ATTR_DATE_TO = "date_to"

--- a/custom_components/eso/eso_client.py
+++ b/custom_components/eso/eso_client.py
@@ -367,7 +367,12 @@ class ESOClient:
         self.session.cookies = requests.utils.cookiejar_from_dict(jar)
         return True
 
-    def fetch(self, obj: str, date: datetime) -> dict:
+    def fetch(
+        self,
+        obj: str,
+        date: datetime,
+        date_range: tuple[datetime, datetime] | None = None,
+    ) -> dict:
         if not self.cookies:
             _LOGGER.error("Cookies are empty. Check your credentials.")
             return {}
@@ -396,6 +401,13 @@ class ESOClient:
             "_drupal_ajax": "1",
             "_triggering_element_name": "display_type",
         }
+        if date_range is not None:
+            # The weekly view ignores active_date_value and always renders the
+            # last 7 days; the "Kita" (custom) period is the only server-side
+            # path to historical hourly data.
+            data["period"] = "other"
+            data["other_start"] = date_range[0].strftime("%Y-%m-%d")
+            data["other_end"] = date_range[1].strftime("%Y-%m-%d")
         try:
             response = self.session.post(
                 GENERATION_URL,
@@ -415,7 +427,31 @@ class ESOClient:
         if obj in self.dataset:
             return self.dataset[obj]
         self.dataset[obj] = {}
-        data = self.fetch(obj, date)
+        self._merge_response(obj, self.fetch(obj, date))
+        return self.dataset[obj]
+
+    def fetch_dataset_range(
+        self, obj: str, date_from: datetime, date_to: datetime
+    ) -> dict | None:
+        """Fetch hourly data for an arbitrary date range (history backfill).
+
+        Uses the form's "Kita" (custom) period, which returns the whole range
+        hourly in one response; very long ranges are split into ~90-day
+        requests. The merged series is sorted chronologically because the
+        statistics writer builds cumulative sums in iteration order."""
+        self.dataset[obj] = {}
+        start = date_from
+        while start <= date_to:
+            end = min(start + timedelta(days=89), date_to)
+            self._merge_response(obj, self.fetch(obj, end, date_range=(start, end)))
+            start = end + timedelta(days=1)
+            if start <= date_to:
+                time.sleep(1)
+        for consumption_type, series in self.dataset[obj].items():
+            self.dataset[obj][consumption_type] = dict(sorted(series.items()))
+        return self.dataset[obj]
+
+    def _merge_response(self, obj: str, data: dict) -> None:
         for d in data:
             if d.get("command") == "update_build_id":
                 self.form_parser.set("form_build_id", d["new"])
@@ -429,8 +465,7 @@ class ESOClient:
                 consumption_type = dataset["key"]
                 if consumption_type not in self.dataset[obj]:
                     self.dataset[obj][consumption_type] = {}
-                self.dataset[obj][consumption_type] = self.parse_dataset(dataset)
-        return self.dataset[obj]
+                self.dataset[obj][consumption_type].update(self.parse_dataset(dataset))
 
     def get_dataset(self, obj: str) -> dict | None:
         if obj not in self.dataset:

--- a/custom_components/eso/eso_client.py
+++ b/custom_components/eso/eso_client.py
@@ -488,7 +488,7 @@ class ESOClient:
 
     def fetch_dataset_range(
         self, obj: str, date_from: datetime, date_to: datetime
-    ) -> dict | None:
+    ) -> dict:
         """Fetch hourly data for an arbitrary date range (history backfill).
 
         Uses the form's "Kita" (custom) period, which returns the whole range

--- a/custom_components/eso/services.yaml
+++ b/custom_components/eso/services.yaml
@@ -6,3 +6,13 @@ import_now:
       selector:
         config_entry:
           integration: eso
+    date_from:
+      required: false
+      example: "2026-01-01"
+      selector:
+        date:
+    date_to:
+      required: false
+      example: "2026-07-16"
+      selector:
+        date:


### PR DESCRIPTION
## What

Adds optional `date_from` / `date_to` fields to the `eso.import_now` service so historical hourly data can be backfilled into long-term statistics.

## Why

The consumption form's weekly view always renders only the last 7 days regardless of `active_date_value`, so any gap older than a week (new installation, prolonged fetch failures, or simply wanting full history since contract start) was previously unrecoverable.

## How

- `ESOClient.fetch()` accepts an optional date range and switches the form to its "Kita" (custom) period, which returns the whole range hourly in one response.
- `fetch_dataset_range()` splits very long ranges into ~90-day requests (1 s apart) and sorts the merged series chronologically, because the statistics writer builds cumulative sums in iteration order.
- The response-merging logic is factored out of `fetch_dataset()` into `_merge_response()` so both paths share it.
- The service validates the range (`date_to` requires `date_from`, `date_from <= date_to`) and backfill runs are user-invoked one-offs, so the silent retry-later path is skipped for them.

Cumulative sums continue from the last stored statistic (existing `get_previous_sum()` lookback), so backfilled history slots in cleanly next to already-imported data.

## Tested

Running in my production HA: backfilled ~1.5 years of hourly history for one object in ~90-day chunks; sums lined up with the portal's own monthly totals.
