### PR TITLE
Add official storage-bank (stored energy) sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ Each object (metering point) exposes the following settings via **Reconfigure**:
 | price_entity   | string  |    no    |         | Name of an entity tracking electricity price         |
 | price_currency | string  |    no    |   EUR   | Currency of electricity price                        |
 
+### Stored energy (storage bank) sensor
+
+For objects with **returned** enabled, the integration creates a
+`sensor.eso_stored_energy_<object_id>` entity with the official storage-bank
+("pasaugojimas") balance from the self-service portal — the same number the
+portal shows under *Rodyti sukauptos energijos kiekį*.
+
+The sensor reports the balance (kWh) at the end of the last **closed** month of
+the current bank year (April 1 – March 31); ESO reports the still-open month as
+0 until it closes it. The full monthly series is available in the `series`
+attribute. Note that the bank never goes below zero: a deficit month (imported
+more than exported) drains it at most to 0, so a running `returned − consumed`
+sum can understate the real balance. The sensor refreshes together with the
+daily import and keeps its last value across restarts.
+
 ### Example with cost calculation
 
 The example below is using the [Nord Pool integration for Home Assistant](https://github.com/custom-components/nordpool).

--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
 import homeassistant.helpers.config_validation as cv
@@ -27,6 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later, async_track_point_in_time
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -55,10 +56,13 @@ from .const import (
     SERVICE_IMPORT_NOW,
     SESSION_FILE,
     SUBENTRY_TYPE_OBJECT,
+    signal_stored_updated,
 )
 from .eso_client import ESOClient
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["sensor"]
 
 DAILY_IMPORT_WINDOW_START_HOUR = 5
 DAILY_IMPORT_WINDOW_START_MINUTE = 10
@@ -71,6 +75,8 @@ class ESORuntimeData:
 
     client: ESOClient
     async_import: Callable[[datetime], Awaitable[None]]
+    # Latest storage-bank series per object id: {"YYYY-MM": kWh at month end}
+    stored: dict[str, dict[str, float]] = field(default_factory=dict)
 
 
 type ESOConfigEntry = ConfigEntry[ESORuntimeData]
@@ -208,6 +214,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
             await async_insert_statistics(hass, obj, dataset)
             if obj.get(CONF_PRICE_ENTITY):
                 await async_insert_cost_statistics(hass, obj, dataset)
+            if obj.get(CONF_RETURNED):
+                try:
+                    stored = await hass.async_add_executor_job(
+                        client.fetch_stored, obj[CONF_ID]
+                    )
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.error(
+                        "ESO stored-bank fetch error [%s]: %s", obj[CONF_NAME], err
+                    )
+                else:
+                    if stored:
+                        entry.runtime_data.stored[obj[CONF_ID]] = stored
+                        async_dispatcher_send(
+                            hass, signal_stored_updated(entry.entry_id)
+                        )
             _LOGGER.info("Import completed for %s", obj[CONF_NAME])
         if all_failed and not retry:
             _LOGGER.warning("Fetch failed, will retry later")
@@ -248,6 +269,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
         client=client,
         async_import=async_import_generation,
     )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _async_register_services(hass)
     return True
 
@@ -286,6 +308,8 @@ def _async_register_services(hass: HomeAssistant) -> None:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
     """Unload a config entry (scheduling is torn down via async_on_unload)."""
+    if not await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        return False
     remaining = [
         other
         for other in hass.config_entries.async_loaded_entries(DOMAIN)

--- a/custom_components/eso/__init__.py
+++ b/custom_components/eso/__init__.py
@@ -309,7 +309,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ESOConfigEntry) -> bool:
                 await async_insert_fixed_price_cost_statistics(hass, obj, dataset)
             if obj.get(CONF_EXPORT_BALANCE):
                 await async_insert_export_balance_statistics(hass, obj, dataset)
-            if obj.get(CONF_RETURNED):
+            # Storage bank is an ESO portal feature; IgnitisClient has no fetch_stored
+            if obj.get(CONF_RETURNED) and hasattr(client, "fetch_stored"):
                 try:
                     stored = await hass.async_add_executor_job(
                         client.fetch_stored, obj[CONF_ID]

--- a/custom_components/eso/const.py
+++ b/custom_components/eso/const.py
@@ -42,6 +42,11 @@ RETRY_DELAY_SECONDS = 3 * 3600
 # Subentry type: one metering point (object) per subentry
 SUBENTRY_TYPE_OBJECT = "object"
 
+# Dispatcher signal fired after the stored-bank series is refreshed
+def signal_stored_updated(entry_id: str) -> str:
+    return f"{DOMAIN}_{entry_id}_stored_updated"
+
+
 # Service to trigger an on-demand import
 SERVICE_IMPORT_NOW = "import_now"
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"

--- a/custom_components/eso/eso_client.py
+++ b/custom_components/eso/eso_client.py
@@ -367,7 +367,7 @@ class ESOClient:
         self.session.cookies = requests.utils.cookiejar_from_dict(jar)
         return True
 
-    def fetch(self, obj: str, date: datetime) -> dict:
+    def fetch(self, obj: str, date: datetime, stored: bool = False) -> dict:
         if not self.cookies:
             _LOGGER.error("Cookies are empty. Check your credentials.")
             return {}
@@ -396,6 +396,14 @@ class ESOClient:
             "_drupal_ajax": "1",
             "_triggering_element_name": "display_type",
         }
+        if stored:
+            # The "Rodyti sukauptos energijos kiekį" (show stored energy)
+            # checkbox only renders in the monthly view; it adds a `stored`
+            # dataset to the response.
+            data["display_type"] = "monthly"
+            data["period"] = "year"
+            data["stored_energy"] = 1
+            data["_triggering_element_name"] = "stored_energy"
         try:
             response = self.session.post(
                 GENERATION_URL,
@@ -431,6 +439,38 @@ class ESOClient:
                     self.dataset[obj][consumption_type] = {}
                 self.dataset[obj][consumption_type] = self.parse_dataset(dataset)
         return self.dataset[obj]
+
+    def fetch_stored(self, obj: str) -> dict[str, float]:
+        """Return the storage-bank balance ESO reports for each month.
+
+        Keys are ``YYYY-MM`` strings, values are the bank balance (kWh) at that
+        month's end as shown by the portal's "Rodyti sukauptos energijos
+        kiekį" toggle. The balance never goes below zero (a deficit month
+        drains the bank at most to 0) and the current, still-open month is
+        always reported as 0 until ESO closes it."""
+        series: dict[str, float] = {}
+        for d in self.fetch(obj, datetime.now(), stored=True):
+            if d.get("command") == "update_build_id":
+                self.form_parser.set("form_build_id", d["new"])
+                continue
+            if d.get("command") != "settings":
+                continue
+            form = d["settings"].get("eso_consumption_history_form")
+            if not form:
+                continue
+            for dataset in form["graphics_data"]["datasets"]:
+                if dataset.get("key") != "stored":
+                    continue
+                for record in dataset.get("record", []):
+                    if record.get("value") is None:
+                        continue
+                    try:
+                        series[record["date"]] = float(record["value"])
+                    except (TypeError, ValueError):
+                        _LOGGER.warning(
+                            "ESO: unparsable stored record %s", record
+                        )
+        return series
 
     def get_dataset(self, obj: str) -> dict | None:
         if obj not in self.dataset:

--- a/custom_components/eso/sensor.py
+++ b/custom_components/eso/sensor.py
@@ -1,0 +1,99 @@
+"""Sensor exposing the official ESO storage-bank ("pasaugojimas") balance.
+
+The value comes straight from the portal's "Rodyti sukauptos energijos
+kiekį" monthly series (see ESOClient.fetch_stored): the balance at the end
+of the last closed month of the current bank year (Apr 1 – Mar 31). The
+still-open month is always reported as 0 by ESO, so it is ignored; months
+from a previous bank year are ignored too because that credit burned on
+March 31.
+"""
+
+import logging
+
+from homeassistant.components.sensor import (
+    RestoreSensor,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigSubentry
+from homeassistant.const import CONF_ID, CONF_NAME, UnitOfEnergy
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_RETURNED, SUBENTRY_TYPE_OBJECT, signal_stored_updated
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> None:
+    """Add a bank sensor for every object that exports to the grid."""
+    for subentry in entry.subentries.values():
+        if subentry.subentry_type != SUBENTRY_TYPE_OBJECT:
+            continue
+        if not subentry.data.get(CONF_RETURNED):
+            continue
+        async_add_entities(
+            [ESOStoredBankSensor(entry, subentry)],
+            config_subentry_id=subentry.subentry_id,
+        )
+
+
+class ESOStoredBankSensor(RestoreSensor):
+    """Official storage-bank balance for one metering object."""
+
+    _attr_should_poll = False
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_device_class = SensorDeviceClass.ENERGY_STORAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:bank"
+
+    def __init__(self, entry, subentry: ConfigSubentry) -> None:
+        self._entry = entry
+        self._obj_id: str = subentry.data[CONF_ID]
+        self._obj_name: str = subentry.data.get(CONF_NAME, self._obj_id)
+        self._attr_unique_id = f"{self._obj_id}_stored_bank"
+        self._attr_name = f"ESO stored energy {self._obj_id}"
+        self._attr_extra_state_attributes = {}
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        # Data arrives once a day after the scheduled import; survive
+        # restarts on the previously reported balance.
+        if (last := await self.async_get_last_sensor_data()) is not None:
+            self._attr_native_value = last.native_value
+        if (state := await self.async_get_last_state()) is not None:
+            self._attr_extra_state_attributes = {
+                key: state.attributes[key]
+                for key in ("month", "series")
+                if key in state.attributes
+            }
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                signal_stored_updated(self._entry.entry_id),
+                self._handle_update,
+            )
+        )
+        self._handle_update()
+
+    @callback
+    def _handle_update(self) -> None:
+        series = self._entry.runtime_data.stored.get(self._obj_id)
+        if not series:
+            return
+        now = dt_util.now()
+        bank_year_start = f"{now.year if now.month >= 4 else now.year - 1}-04"
+        current_month = now.strftime("%Y-%m")
+        closed = {
+            month: value
+            for month, value in series.items()
+            if bank_year_start <= month < current_month
+        }
+        last_month = max(closed) if closed else None
+        self._attr_native_value = closed[last_month] if last_month else 0.0
+        self._attr_extra_state_attributes = {
+            "month": last_month,
+            "series": series,
+        }
+        self.async_write_ha_state()

--- a/custom_components/eso/sensor.py
+++ b/custom_components/eso/sensor.py
@@ -90,8 +90,17 @@ class ESOStoredBankSensor(RestoreSensor):
             for month, value in series.items()
             if bank_year_start <= month < current_month
         }
+        if not closed:
+            # April: current bank year has no closed month yet; the previous
+            # bank year's balance is still the real one until ESO closes April.
+            prev_start = f"{int(bank_year_start[:4]) - 1}-04"
+            closed = {
+                month: value
+                for month, value in series.items()
+                if prev_start <= month < bank_year_start
+            }
         last_month = max(closed) if closed else None
-        self._attr_native_value = closed[last_month] if last_month else 0.0
+        self._attr_native_value = closed[last_month] if last_month else None
         self._attr_extra_state_attributes = {
             "month": last_month,
             "series": series,


### PR DESCRIPTION
## What

Adds a `sensor.eso_stored_energy_<object_id>` entity (for objects with **returned** enabled) carrying the official storage-bank ("pasaugojimas") balance from the self-service portal — the same number shown by the portal's *Rodyti sukauptos energijos kiekį* toggle.

## Why

Prosumers on the storage plan otherwise have to reconstruct the bank as a running `returned − consumed` sum, and that reconstruction is subtly wrong: the bank never goes below zero, so a deficit month (imported more than exported) drains it at most to 0 while a plain sum keeps subtracting. In my case the reconstructed balance understated the real bank by ~274 kWh after a single deficit month. The portal's own number is authoritative.

## How

- The consumption form has a monthly-view-only `stored_energy=1` checkbox; with it, the AJAX response carries an extra `stored` dataset: the bank balance (kWh) at each month's end. `ESOClient.fetch_stored()` requests the monthly/year view with that flag and parses the series.
- The series is fetched during the existing daily import (one extra AJAX call on the already-authenticated session, only for objects with `returned` enabled) and handed to the sensor via a dispatcher signal.
- The sensor reports the last **closed** month of the current bank year (April 1 – March 31): ESO always reports the still-open month as 0, and credit from a previous bank year burned on March 31. The full monthly series is exposed as an attribute.
- `RestoreSensor`, so the value survives restarts between daily imports.

Observed dataset for reference (response of the monthly view with `stored_energy=1`):

```
{"key": "stored", "label": "Sukaupta energija", "record": [
  {"date": "2026-05", "value": 65}, {"date": "2026-06", "value": 269}, {"date": "2026-07", "value": 0}, ...]}
```

## Tested

Running in my production HA: sensor reports 269 kWh (June month-end), matching the portal exactly; month-over-month deltas match the hourly P+/P− statistics the integration already imports.

Note: touches the same region of `ESOClient.fetch()` as #39 — whichever lands second may need a trivial rebase.
