### PR TITLE
eso_client: support delegated accounts (access-rights / atstovavimas)

### DIFF
--- a/custom_components/eso/eso_client.py
+++ b/custom_components/eso/eso_client.py
@@ -18,6 +18,16 @@ LOGIN_URL = "https://mano.eso.lt/?destination=/consumption"
 GENERATION_URL = "https://mano.eso.lt/consumption?ajax_form=1&_wrapper_format=drupal_ajax"
 TFA_FORM_ID = "gpc_tfa_login_auth_form"
 CONSUMPTION_FORM_ID = "eso_consumption_history_form"
+BASE_URL = "https://mano.eso.lt"
+# Accounts that only received access to an object through ESO's access-rights
+# sharing ("atstovavimas") land on a profile with no objects of its own; the
+# consumption page then shows "Objektas nerastas" until the session is
+# switched to the granting profile. The switch is a plain GET link carrying a
+# session-bound CSRF token. ESO renders the account menu inside JSON-escaped
+# AJAX payloads, so the pattern tolerates escaped slashes.
+PROFILE_SWITCH_RE = re.compile(
+    r"access-rights(?:\\/|/)(\d+)(?:\\/|/)switch-to\?token=([A-Za-z0-9_\-\.~%]+)"
+)
 
 class ESOError(Exception):
     """Base error for ESO client failures."""
@@ -58,6 +68,7 @@ class ESOClient:
         self.cookies: dict | None = None
         self.form_parser: FormParser = FormParser()
         self.dataset: dict = {}
+        self._last_page_html: str = ""
 
     @staticmethod
     def _new_session() -> requests.Session:
@@ -160,13 +171,58 @@ class ESOClient:
     def _open_consumption(self) -> bool:
         """GET the consumption page with the current session and parse its
         Drupal form tokens. Returns True when the session is authenticated
-        (i.e. the consumption form is present rather than the login form)."""
+        (i.e. the consumption form is present rather than the login form).
+
+        When the form is missing but the session offers an access-rights
+        profile switch link, follow it once and retry: the account itself may
+        have no objects, with the real objects living on a profile shared
+        with it via ESO access rights (delegated account)."""
+        if self._load_consumption_form():
+            return True
+        if self._switch_profile():
+            return self._load_consumption_form()
+        return False
+
+    def _load_consumption_form(self) -> bool:
         self.form_parser = FormParser()
         response = self.session.get(LOGIN_URL, allow_redirects=True)
         response.raise_for_status()
         self.cookies = requests.utils.dict_from_cookiejar(self.session.cookies)
+        self._last_page_html = response.text
         self.form_parser.feed(response.text)
         return self.form_parser.get("form_id") == CONSUMPTION_FORM_ID
+
+    def _switch_profile(self) -> bool:
+        """Follow the first access-rights profile switch link offered to the
+        session, looking first at the last fetched page and falling back to
+        the /access-rights management page. Returns True when a switch link
+        was found and requested."""
+        match = PROFILE_SWITCH_RE.search(self._last_page_html or "")
+        if not match:
+            try:
+                page = self.session.get(
+                    BASE_URL + "/access-rights", allow_redirects=True
+                )
+                page.raise_for_status()
+            except requests.exceptions.RequestException as err:
+                _LOGGER.debug("ESO: /access-rights request failed: %s", err)
+                return False
+            match = PROFILE_SWITCH_RE.search(page.text)
+            if not match:
+                return False
+        url = "%s/access-rights/%s/switch-to?token=%s" % (
+            BASE_URL,
+            match.group(1),
+            match.group(2),
+        )
+        _LOGGER.info(
+            "ESO: consumption form not found, switching to delegated profile"
+            " (access right %s)",
+            match.group(1),
+        )
+        response = self.session.get(url, allow_redirects=True)
+        response.raise_for_status()
+        return True
 
     def _full_login(self) -> None:
         """Submit the username/password form. ESO redirects to the TFA page


### PR DESCRIPTION
# Support delegated accounts / managed properties (atstovavimas)

Fixes #32

## Problem

When an ESO account only *received* access to an object through ESO's
access-rights sharing ("atstovavimas"), logging in lands on a profile with no
objects of its own. The consumption page shows **"Objektas nerastas"**, so the
integration fails with `ESO login did not reach the consumption page` even
though credentials and 2FA are correct. The only workaround was using the
property owner's credentials directly.

## How ESO exposes the switch

After login, the portal offers a profile-switch link of the form
`/access-rights/<id>/switch-to?token=<csrf>`. Two implementation details make
this non-trivial to consume from `requests`:

1. The token is **session-bound**, so it must be scraped fresh from the HTML
   of the logged-in session on every login — it cannot be configured statically.
2. ESO renders the account menu inside **JSON-escaped AJAX payloads**
   (`href=\u0022\/access-rights\/...`), so a naive `href="/access-rights/..."`
   pattern never matches the raw HTML. The new pattern tolerates escaped
   slashes and extracts the access-right id and token as groups.

## Change

* `_open_consumption()` — when the consumption form is absent, attempt a
  single delegated-profile switch and retry. Accounts with their own objects
  are unaffected (the form is found on the first try and no extra request is
  made).
* `_switch_profile()` — locate the switch link on the last fetched page,
  falling back to `/access-rights`, then follow it within the same session.
* `PROFILE_SWITCH_RE` — escape-tolerant pattern described above.

## Testing

Verified on a real delegated-account setup (HA 2026.7.2): login + IMAP 2FA →
"Objektas nerastas" state detected → profile switched → consumption form
found → objects discovered → config entry created and loaded → statistics
imported successfully. Accounts observed only one shared profile; when several
access rights exist the first offered link is used (a config option for
choosing among several could be a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
